### PR TITLE
Added Travis build status badge [skip ci]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# Copyright 2019 JanusGraph.Net authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+root = true
+
+[*]
+insert_final_newline = false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # JanusGraph.Net
 
+[![Build Status][Travis-badge]][Travis-url]
+
 JanusGraph.Net is the .NET driver of [JanusGraph][JanusGraph]. It extends
 Apache TinkerPop™'s [Gremlin.Net][Gremlin.Net] as its core dependency
 with additional support for JanusGraph-specific types.
@@ -46,6 +48,8 @@ and documentation is provided under the [CC-BY-4.0 license](CC-BY-4.0.txt). For
 details about this dual-license structure, please see
 [`LICENSE.txt`](LICENSE.txt).
 
+[Travis-badge]: https://travis-ci.org/JanusGraph/janusgraph-dotnet.svg?branch=master
+[Travis-url]: https://travis-ci.org/JanusGraph/janusgraph-dotnet
 [JanusGraph]: http://janusgraph.org/
 [Gremlin.Net]: http://tinkerpop.apache.org/docs/current/reference/#gremlin-DotNet
 [text-predicates]: https://docs.janusgraph.org/latest/search-predicates.html#_text_predicate


### PR DESCRIPTION
Also added `.editorconfig` file since it looks like files in this repository
don't have EOL at EOF, so this config ensures that folks won't create spurious
diffs when editing files (as my editor did initially, before I added this
config).

This, of course, requires contributors to install the EditorConfig plugin for
their editor or IDE, but at least the settings can be uniformly maintained for
many different editors in a single config file.