### PR TITLE
Enable continuous deployment via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,9 @@ before_install:
   - source /etc/profile.d/dotnet-cli-tools-bin-path.sh
 script:
   - dotnet cake
+deploy:
+  provider: script
+  skip_cleanup: true
+  script: dotnet cake --target=Push --apiKey=$NUGET_API_KEY
+  on:
+    tags: true

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -32,6 +32,28 @@ dotnet cake --target=Pack
 The shown `Pack` task packs the library into a NuGet package after building and
 testing it.
 
+## Deployment
+
+We use continuous deployment via Travis to push NuGet packages to nuget.org.
+To create a new release, you only have to create a [git tag][git-tag] for the
+release:
+
+```sh
+git tag -a v0.1.0 -m "JanusGraph.Net 0.1.0 release"
+```
+
+and then push this tag:
+
+```sh
+git push origin v0.1.0
+```
+
+This will trigger a deployment via Travis after the usual build has completed
+successfully.
+The version number used for the tag should correspond to the version in the
+`.csproj` file as that version is used for the NuGet package.
+
 [cake]: https://cakebuild.net/
 [dotnet-sdk]: https://www.microsoft.com/net/download
 [docker]: https://www.docker.com/
+[git-tag]: https://git-scm.com/book/en/v2/Git-Basics-Tagging

--- a/build.cake
+++ b/build.cake
@@ -17,6 +17,8 @@
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
 var artifactsDir = Argument("artifactsDir", "artifacts");
+var apiKey = Argument("apiKey", "");
+var nugetSource = Argument("nugetSource", "https://api.nuget.org/v3/index.json");
 var solutionPath = SolutionPath().FullPath;
 
 Task("Clean")
@@ -50,6 +52,16 @@ Task("Pack")
         DotNetCorePack(srcProject.FullPath, settings);
     });
 
+Task("Push")
+    .DoesForEach(() => NuGetPackages(), (nugetPackage) => {
+        var settings = new DotNetCoreNuGetPushSettings
+        {
+            ApiKey = apiKey,
+            Source = nugetSource
+        };
+        DotNetCoreNuGetPush(nugetPackage.FullPath, settings);
+    });
+
 Task("Default")
     .IsDependentOn("Test");
 
@@ -68,4 +80,9 @@ FilePathCollection TestProjects()
 FilePathCollection SourceProjects()
 {
 	return GetFiles("./src/**/*.csproj");
+}
+
+FilePathCollection NuGetPackages()
+{
+    return GetFiles($"{artifactsDir}/*.nupkg");
 }


### PR DESCRIPTION
Deployment is triggered by creating a git tag as described in `BUILDING.md`.
I added the NuGet API key in the web interface of Travis.

Fixes #10