### PR TITLE
Update Gremlin.Net to 3.4.2

### DIFF
--- a/src/JanusGraph.Net/JanusGraph.Net.csproj
+++ b/src/JanusGraph.Net/JanusGraph.Net.csproj
@@ -21,6 +21,6 @@
     <PackageIconUrl>https://raw.githubusercontent.com/JanusGraph/logos/master/RGB%20-%20PNG%20small/JanusGraph%20logomark%20color%20RGB.png</PackageIconUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Gremlin.Net" Version="3.3.3" />
+    <PackageReference Include="Gremlin.Net" Version="3.4.2" />
   </ItemGroup>
 </Project>

--- a/src/JanusGraph.Net/JanusGraphClientBuilder.cs
+++ b/src/JanusGraph.Net/JanusGraphClientBuilder.cs
@@ -33,6 +33,7 @@ namespace JanusGraph.Net
         private readonly GremlinServer _server;
         private readonly JanusGraphSONReaderBuilder _readerBuilder = JanusGraphSONReaderBuilder.Build();
         private readonly JanusGraphSONWriterBuilder _writerBuilder = JanusGraphSONWriterBuilder.Build();
+        private ConnectionPoolSettings _connectionPoolSettings;
 
         private JanusGraphClientBuilder(GremlinServer server)
         {
@@ -71,11 +72,22 @@ namespace JanusGraph.Net
         }
 
         /// <summary>
+        ///     Configures the <see cref="ConnectionPoolSettings"/> for the client.
+        /// </summary>
+        /// <param name="connectionPoolSettings">The connection pool settings to use.</param>
+        public JanusGraphClientBuilder WithConnectionPoolSettings(ConnectionPoolSettings connectionPoolSettings)
+        {
+            _connectionPoolSettings = connectionPoolSettings;
+            return this;
+        }
+
+        /// <summary>
         ///     Creates the <see cref="IGremlinClient" /> with the given settings and pre-configured for JanusGraph.
         /// </summary>
         public IGremlinClient Create()
         {
-            return new GremlinClient(_server, _readerBuilder.Create(), _writerBuilder.Create());
+            return new GremlinClient(_server, _readerBuilder.Create(), _writerBuilder.Create(),
+                connectionPoolSettings: _connectionPoolSettings);
         }
     }
 }

--- a/test/JanusGraph.Net.IntegrationTest/DocTraversalsTests.cs
+++ b/test/JanusGraph.Net.IntegrationTest/DocTraversalsTests.cs
@@ -19,9 +19,9 @@
 #endregion
 
 using System;
-using Gremlin.Net.Structure;
 using JanusGraph.Net.Geoshapes;
 using Xunit;
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace JanusGraph.Net.IntegrationTest
 {
@@ -38,7 +38,7 @@ namespace JanusGraph.Net.IntegrationTest
         [Fact]
         public void GremlinNetGettingStartedTest()
         {
-            var g = new Graph().Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
+            var g = Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
 
             var herculesAge = g.V().Has("name", "hercules").Values<int>("age").Next();
 
@@ -48,7 +48,7 @@ namespace JanusGraph.Net.IntegrationTest
         [Fact]
         public void ReceivingEdgesTest()
         {
-            var g = new Graph().Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
+            var g = Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
             
             var edges = g.V().Has("name","hercules").OutE("battled").ToList();
             
@@ -58,7 +58,7 @@ namespace JanusGraph.Net.IntegrationTest
         [Fact]
         public void TextContainsPredicateTest()
         {
-            var g = new Graph().Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
+            var g = Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
             
             var reasons = g.E().Has("reason", Text.TextContains("loves")).ToList();
             
@@ -68,7 +68,7 @@ namespace JanusGraph.Net.IntegrationTest
         [Fact]
         public void GeoTypesPointsReceivedTest()
         {
-            var g = new Graph().Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
+            var g = Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
             
             var firstBattlePlace = g.V().Has("name", "hercules").OutE("battled").Order().By("time")
                 .Values<Point>("place").Next();
@@ -80,7 +80,7 @@ namespace JanusGraph.Net.IntegrationTest
         [Fact]
         public void GeoTypesPointAsArgumentTest()
         {
-            var g = new Graph().Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
+            var g = Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
             
             g.V().Has("name", "hercules").OutE("battled").Has("place", Geoshape.Point(38.1f, 23.7f)).Next();
         }

--- a/test/JanusGraph.Net.IntegrationTest/IO/GraphSON/GeoshapeDeserializerTests.cs
+++ b/test/JanusGraph.Net.IntegrationTest/IO/GraphSON/GeoshapeDeserializerTests.cs
@@ -20,9 +20,9 @@
 
 using System;
 using System.Threading.Tasks;
-using Gremlin.Net.Structure;
 using JanusGraph.Net.Geoshapes;
 using Xunit;
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace JanusGraph.Net.IntegrationTest.IO.GraphSON
 {
@@ -39,7 +39,7 @@ namespace JanusGraph.Net.IntegrationTest.IO.GraphSON
         [Fact]
         public async Task TraversalWithPointPropertyValue_PointReturned_ExpectedPoint()
         {
-            var g = new Graph().Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
+            var g = Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
 
             var place = await g.V().Has("demigod", "name", "hercules").OutE("battled").Has("time", 1)
                 .Values<Point>("place").Promise(t => t.Next());

--- a/test/JanusGraph.Net.IntegrationTest/IO/GraphSON/GeoshapeSerializerTests.cs
+++ b/test/JanusGraph.Net.IntegrationTest/IO/GraphSON/GeoshapeSerializerTests.cs
@@ -20,9 +20,9 @@
 
 using System;
 using System.Threading.Tasks;
-using Gremlin.Net.Structure;
 using JanusGraph.Net.Geoshapes;
 using Xunit;
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace JanusGraph.Net.IntegrationTest.IO.GraphSON
 {
@@ -39,7 +39,7 @@ namespace JanusGraph.Net.IntegrationTest.IO.GraphSON
         [Fact]
         public async Task TraversalWithPointHasFilter_ExistingPoint_ElementFound()
         {
-            var g = new Graph().Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
+            var g = Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
 
             var count = await g.V().Has("demigod", "name", "hercules").OutE("battled")
                 .Has("place", Geoshape.Point(38.1f, 23.7f)).Count().Promise(t => t.Next());

--- a/test/JanusGraph.Net.IntegrationTest/IO/GraphSON/RelationIdentifierDeserializerTests.cs
+++ b/test/JanusGraph.Net.IntegrationTest/IO/GraphSON/RelationIdentifierDeserializerTests.cs
@@ -20,8 +20,8 @@
 
 using System;
 using System.Threading.Tasks;
-using Gremlin.Net.Structure;
 using Xunit;
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace JanusGraph.Net.IntegrationTest.IO.GraphSON
 {
@@ -38,7 +38,7 @@ namespace JanusGraph.Net.IntegrationTest.IO.GraphSON
         [Fact]
         public async Task TraversalWithEdgeId_RelationIdentifierReturned_ValidRelationIdentifier()
         {
-            var g = new Graph().Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
+            var g = Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
 
             var relationIdentifier =
                 await g.V().Has("demigod", "name", "hercules").OutE("father").Id().Promise(t => t.Next());
@@ -49,7 +49,7 @@ namespace JanusGraph.Net.IntegrationTest.IO.GraphSON
         [Fact]
         public async Task TraversalWithEdge_EdgeReturned_EdgeWithIdOfTypeRelationIdentifier()
         {
-            var g = new Graph().Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
+            var g = Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
 
             var edge = await g.V().Has("demigod", "name", "hercules").OutE("father").Promise(t => t.Next());
 

--- a/test/JanusGraph.Net.IntegrationTest/IO/GraphSON/RelationIdentifierSerializerTests.cs
+++ b/test/JanusGraph.Net.IntegrationTest/IO/GraphSON/RelationIdentifierSerializerTests.cs
@@ -20,8 +20,8 @@
 
 using System;
 using System.Threading.Tasks;
-using Gremlin.Net.Structure;
 using Xunit;
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace JanusGraph.Net.IntegrationTest.IO.GraphSON
 {
@@ -38,7 +38,7 @@ namespace JanusGraph.Net.IntegrationTest.IO.GraphSON
         [Fact]
         public async Task TraversalWithRelationIdentifierAsEdgeId_ExistingEdgeId_EdgeFound()
         {
-            var g = new Graph().Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
+            var g = Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
             var edgeId = await g.E().Id().Promise(t => t.Next());
             
             var count = await g.E(edgeId).Count().Promise(t => t.Next());
@@ -49,7 +49,7 @@ namespace JanusGraph.Net.IntegrationTest.IO.GraphSON
         [Fact]
         public async Task TraversalWithEdge_ExistingEdge_EdgeFound()
         {
-            var g = new Graph().Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
+            var g = Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
             var edge = await g.E().Promise(t => t.Next());
 
             var count = await g.E(edge).Count().Promise(t => t.Next());

--- a/test/JanusGraph.Net.IntegrationTest/TextTests.cs
+++ b/test/JanusGraph.Net.IntegrationTest/TextTests.cs
@@ -22,6 +22,7 @@ using System;
 using System.Threading.Tasks;
 using Gremlin.Net.Structure;
 using Xunit;
+using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
 
 namespace JanusGraph.Net.IntegrationTest
 {
@@ -40,7 +41,7 @@ namespace JanusGraph.Net.IntegrationTest
         [InlineData("shouldNotBeFound", 0)]
         public async Task TextContainsgivenSearchText_ExpectedCountOfElements(string searchText, int expectedCount)
         {
-            var g = new Graph().Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
+            var g = Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
 
             var count = await g.E().Has("reason", Text.TextContains(searchText)).Count().Promise(t => t.Next());
 
@@ -53,7 +54,7 @@ namespace JanusGraph.Net.IntegrationTest
         [InlineData("shouldNotBeFound", 0)]
         public async Task TextContainsPrefixgivenSearchText_ExpectedCountOfElements(string searchText, int expectedCount)
         {
-            var g = new Graph().Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
+            var g = Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
 
             var count = await g.E().Has("reason", Text.TextContainsPrefix(searchText)).Count().Promise(t => t.Next());
 
@@ -66,7 +67,7 @@ namespace JanusGraph.Net.IntegrationTest
         [InlineData("shouldNotBeFound", 0)]
         public async Task TextContainsRegexgivenRegex_ExpectedCountOfElements(string regex, int expectedCount)
         {
-            var g = new Graph().Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
+            var g = Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
 
             var count = await g.E().Has("reason", Text.TextContainsRegex(regex)).Count().Promise(t => t.Next());
 
@@ -78,7 +79,7 @@ namespace JanusGraph.Net.IntegrationTest
         [InlineData("shouldNotBeFound", 0)]
         public async Task TextContainsFuzzygivenSearchText_ExpectedCountOfElements(string searchText, int expectedCount)
         {
-            var g = new Graph().Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
+            var g = Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
 
             var count = await g.E().Has("reason", Text.TextContainsFuzzy(searchText)).Count().Promise(t => t.Next());
 
@@ -91,7 +92,7 @@ namespace JanusGraph.Net.IntegrationTest
         [InlineData("shouldNotBeFound", 0)]
         public async Task TextPrefixgivenSearchText_ExpectedCountOfElements(string searchText, int expectedCount)
         {
-            var g = new Graph().Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
+            var g = Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
 
             var count = await g.V().Has("name", Text.TextPrefix(searchText)).Count().Promise(t => t.Next());
 
@@ -104,7 +105,7 @@ namespace JanusGraph.Net.IntegrationTest
         [InlineData("shouldNotBeFound", 0)]
         public async Task TextRegexgivenRegex_ExpectedCountOfElements(string regex, int expectedCount)
         {
-            var g = new Graph().Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
+            var g = Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
 
             var count = await g.V().Has("name", Text.TextRegex(regex)).Count().Promise(t => t.Next());
 
@@ -117,7 +118,7 @@ namespace JanusGraph.Net.IntegrationTest
         [InlineData("shouldNotBeFound", 0)]
         public async Task TextFuzzygivenSearchText_ExpectedCountOfElements(string searchText, int expectedCount)
         {
-            var g = new Graph().Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
+            var g = Traversal().WithRemote(_connectionFactory.CreateRemoteConnection());
 
             var count = await g.V().Has("name", Text.TextFuzzy(searchText)).Count().Promise(t => t.Next());
 


### PR DESCRIPTION
Changes apart from the version bump:
- Gremlin.Net now uses a connection pool. This pool can be configured via the added `ConnectionPoolSettings` that are now also exposed in the `JanusGraphClientBuilder`.
- `new Graph().Traversal()` is now deprecated and [the static method `Traversal()` should be used instead](http://tinkerpop.apache.org/docs/3.4.2/upgrade/#_anonymoustraversalsource).
- Since the `GremlinClient` now automatically creates a connection to the server on construction instead of waiting for the first request, it was necessary to change the way we check for the availability of the test container.

I opted for version 3.4.2 here as it contains [two bug fixes for Gremlin.Net](https://issues.apache.org/jira/browse/TINKERPOP-2217?jql=project%20%3D%20TINKERPOP%20AND%20status%20%3D%20Closed%20AND%20fixVersion%20%3D%203.4.2%20AND%20component%20%3D%20dotnet) compared to version 3.4.1 which is the version JanusGraph 0.4.0 uses.

Fixes #16.