### PR TITLE
Use official JanusGraph Docker image

### DIFF
--- a/test/JanusGraph.Net.IntegrationTest/JanusGraph.Net.IntegrationTest.csproj
+++ b/test/JanusGraph.Net.IntegrationTest/JanusGraph.Net.IntegrationTest.csproj
@@ -4,12 +4,11 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Polly" Version="6.1.0" />
-    <PackageReference Include="TestContainers" Version="0.0.2.55" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="TestContainers" Version="0.0.2.107" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
@@ -17,6 +16,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="load_data.groovy">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/test/JanusGraph.Net.IntegrationTest/JanusGraphServerFixture.cs
+++ b/test/JanusGraph.Net.IntegrationTest/JanusGraphServerFixture.cs
@@ -34,12 +34,14 @@ namespace JanusGraph.Net.IntegrationTest
         {
             var config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
             var dockerImage = config["dockerImage"];
-            var port = Convert.ToInt32(config["serverPort"]);
             _container = new GenericContainerBuilder<GremlinServerContainer>()
                 .Begin()
                 .WithImage(dockerImage)
-                .WithExposedPorts(port)
+                .WithExposedPorts(GremlinServerContainer.GremlinServerPort)
+                .WithMountPoints(($"{AppContext.BaseDirectory}/load_data.groovy",
+                    "/docker-entrypoint-initdb.d/load_data.groovy", "bind"))
                 .Build();
+            _container.ServerStartedCheckTraversal = "g.V().has('name', 'hercules').hasNext()";
         }
 
         public string Host => _container.Host;

--- a/test/JanusGraph.Net.IntegrationTest/RemoteConnectionFactory.cs
+++ b/test/JanusGraph.Net.IntegrationTest/RemoteConnectionFactory.cs
@@ -38,11 +38,10 @@ namespace JanusGraph.Net.IntegrationTest
             _port = port;
         }
 
-        public IRemoteConnection CreateRemoteConnection(string traversalSource = "gods_traversal")
+        public IRemoteConnection CreateRemoteConnection()
         {
-            var c = new DriverRemoteConnection(
-                JanusGraphClientBuilder.BuildClientForServer(new GremlinServer(_host, _port)).Create(),
-                traversalSource);
+            var c = new DriverRemoteConnection(JanusGraphClientBuilder
+                .BuildClientForServer(new GremlinServer(_host, _port)).Create());
             _connections.Add(c);
             return c;
         }

--- a/test/JanusGraph.Net.IntegrationTest/appsettings.json
+++ b/test/JanusGraph.Net.IntegrationTest/appsettings.json
@@ -1,4 +1,3 @@
 ﻿{
-  "dockerImage": "florianhockmann/janusgraph-testing:latest",
-  "serverPort": 8182
+  "dockerImage": "janusgraph/janusgraph:latest"
 }

--- a/test/JanusGraph.Net.IntegrationTest/load_data.groovy
+++ b/test/JanusGraph.Net.IntegrationTest/load_data.groovy
@@ -1,0 +1,46 @@
+// Copyright 2019 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+g = traversal().withRemote('conf/remote-graph.properties')
+
+g.addV('titan').property('name', 'saturn').property('age', 10000).as('saturn').
+  addV('location').property('name', 'sky').as('sky').
+  addV('location').property('name', 'sea').as('sea').
+  addV('god').property('name', 'jupiter').property('age', 5000).as('jupiter').
+  addV('god').property('name', 'neptune').property('age', 4500).as('neptune').
+  addV('demigod').property('name', 'hercules').property('age', 30).as('hercules').
+  addV('human').property('name', 'alcmene').property('age', 45).as('alcmene').
+  addV('god').property('name', 'pluto').property('age', 4000).as('pluto').
+  addV('monster').property('name', 'nemean').as('nemean').
+  addV('monster').property('name', 'hydra').as('hydra').
+  addV('monster').property('name', 'cerberus').as('cerberus').
+  addV('location').property('name', 'tartarus').as('tartarus').
+  addE('father').from('jupiter').to('saturn').
+  addE('lives').from('jupiter').to('sky').property('reason', 'loves fresh breezes').
+  addE('brother').from('jupiter').to('neptune').
+  addE('brother').from('jupiter').to('pluto').
+  addE('lives').from('neptune').to('sea').property('reason', 'loves waves').
+  addE('brother').from('neptune').to('jupiter').
+  addE('brother').from('neptune').to('pluto').
+  addE('father').from('hercules').to('jupiter').
+  addE('mother').from('hercules').to('alcmene').
+  addE('battled').from('hercules').to('nemean').property('time', 1).property('place', Geoshape.point(38.1f, 23.7f)).
+  addE('battled').from('hercules').to('hydra').property('time', 2).property('place', Geoshape.point(37.7f, 23.9f)).
+  addE('battled').from('hercules').to('cerberus').property('time', 12).property('place', Geoshape.point(39f, 22f)).
+  addE('brother').from('pluto').to('jupiter').
+  addE('brother').from('pluto').to('neptune').
+  addE('lives').from('pluto').to('tartarus').property('reason', 'no fear of death').
+  addE('pet').from('pluto').to('cerberus').
+  addE('lives').from('cerberus').to('tartarus').
+  iterate()

--- a/test/JanusGraph.Net.UnitTest/JanusGraph.Net.UnitTest.csproj
+++ b/test/JanusGraph.Net.UnitTest/JanusGraph.Net.UnitTest.csproj
@@ -4,9 +4,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The graph of the gods which we use for the tests is now created with a groovy script, thanks to the new Docker image (JanusGraph/janusgraph-docker#16). Having this test data already in the image was the only reason to use a custom one.
This also updates test dependencies, especially to use newer Testcontainers features.

Fixes #19