### PR TITLE
Add Source Link support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ mono: none
 os:
   - linux
 sudo: enabled
-dist: trusty
-dotnet: 2.1
+dist: xenial
+dotnet: 2.2
 services:
   - docker
 before_install:

--- a/src/JanusGraph.Net/JanusGraph.Net.csproj
+++ b/src/JanusGraph.Net/JanusGraph.Net.csproj
@@ -5,6 +5,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>	
     <Version>0.1.0</Version>
     <Title>JanusGraph.Net</Title>
     <Authors>JanusGraph</Authors>
@@ -17,10 +18,12 @@
     <PackageTags>janusgraph;gremlin</PackageTags>
     <PackageProjectUrl>http://janusgraph.org/</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/JanusGraph/janusgraph-dotnet</RepositoryUrl>
     <PackageIcon>JanusGraph logomark color RGB.png</PackageIcon>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01 " PrivateAssets="All"/>
     <PackageReference Include="Gremlin.Net" Version="3.4.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The NuGet Package Explorer shows that Source Link is successfully activated as the _Repository_ element was added which contains the relevant information for Source Link:

![janusgraph_sourcelink_nuget_package_explorer_screenshot](https://user-images.githubusercontent.com/21224336/68238288-2beed700-0009-11ea-9df8-bf8ee7e365e2.JPG)

This also includes the changes from #30 as that's necessary to get a successful build.

Fixes #7 