### PR TITLE
0.2.2 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ of JanusGraph.Net:
 | JanusGraph.Net | JanusGraph |
 |---|---|
 | 0.1.z | 0.3.z |
-| 0.2.z | 0.4.z |
+| 0.2.z | 0.4.z, 0.5.z |
 
 While it should also be possible to use JanusGraph.Net with other versions of
 JanusGraph than mentioned here, compatibility is not tested and some

--- a/src/JanusGraph.Net/JanusGraph.Net.csproj
+++ b/src/JanusGraph.Net/JanusGraph.Net.csproj
@@ -6,7 +6,7 @@
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>	
-    <Version>0.2.1</Version>
+    <Version>0.2.2</Version>
     <Title>JanusGraph.Net</Title>
     <Authors>JanusGraph</Authors>
     <Description>


### PR DESCRIPTION
The 0.2.z versions are already compatible with JanusGraph 0.5.z versions as the TinkerPop version used is still 3.4.z. So, there are no breaking changes for us in JanusGraph 0.5.0.