### PR TITLE
Clarify distribution licenses [skip ci]

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -6,10 +6,11 @@ The JanusGraph project uses the following two licenses:
   which can be found in the file CC-BY-4.0.txt in the root of this repository,
   and included below
 
-The JanusGraph .NET driver is distributed under the following licenses:
+The JanusGraph .NET driver is distributed under the following licenses, and
+contributions are accepted accordingly:
 
-* APACHE-2.0 license for code contributions, including code samples in docs
-* CC-BY-4.0 license for documentation contributions
+* APACHE-2.0 license for code, including code samples in docs
+* CC-BY-4.0 license for documentation
 
 For convenience, copies of APACHE-2.0 and CC-BY-4.0 are included verbatim below.
 


### PR DESCRIPTION
The current statements conflates licenses under which user contributions are
accepted (which are inline in the bullet points), and the licenses under which
the project is distributed.

The new format clarifies that they are the same, and that the licenses apply
separately to code or documentation, and they apply equally whether we're
talking about a user contribution of such assets, or project distribution of
those same assets.

This is similar to the change being made in the JanusGraph FoundationDB storage
adapter in https://github.com/JanusGraph/janusgraph-foundationdb/pull/40