### PR TITLE
Update Gremlin.Net to 3.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ artifacts/
 
 # JetBrains Rider
 .idea/
+*.user

--- a/src/JanusGraph.Net/IO/GraphSON/JanusGraphSONReaderBuilder.cs
+++ b/src/JanusGraph.Net/IO/GraphSON/JanusGraphSONReaderBuilder.cs
@@ -64,7 +64,7 @@ namespace JanusGraph.Net.IO.GraphSON
         ///     Creates a <see cref="GraphSONReader" /> with the registered deserializers as well as the default JanusGraph
         ///     deserializers.
         /// </summary>
-        public GraphSONReader Create()
+        public GraphSON3Reader Create()
         {
             return new GraphSON3Reader(_deserializerByGraphSONType);
         }

--- a/src/JanusGraph.Net/IO/GraphSON/JanusGraphSONWriterBuilder.cs
+++ b/src/JanusGraph.Net/IO/GraphSON/JanusGraphSONWriterBuilder.cs
@@ -65,7 +65,7 @@ namespace JanusGraph.Net.IO.GraphSON
         ///     Creates a <see cref="GraphSONWriter" /> with the registered serializers as well as the default JanusGraph
         ///     serializers.
         /// </summary>
-        public GraphSONWriter Create()
+        public GraphSON3Writer Create()
         {
             return new GraphSON3Writer(_serializerByType);
         }

--- a/src/JanusGraph.Net/IO/GraphSON/RelationIdentifierDeserializer.cs
+++ b/src/JanusGraph.Net/IO/GraphSON/RelationIdentifierDeserializer.cs
@@ -18,16 +18,16 @@
 
 #endregion
 
+using System.Text.Json;
 using Gremlin.Net.Structure.IO.GraphSON;
-using Newtonsoft.Json.Linq;
 
 namespace JanusGraph.Net.IO.GraphSON
 {
     internal class RelationIdentifierDeserializer : IGraphSONDeserializer
     {
-        public dynamic Objectify(JToken graphsonObject, GraphSONReader reader)
+        public dynamic Objectify(JsonElement graphsonObject, GraphSONReader reader)
         {
-            return new RelationIdentifier((string) graphsonObject["relationId"]);
+            return new RelationIdentifier(graphsonObject.GetProperty("relationId").GetString());
         }
     }
 }

--- a/src/JanusGraph.Net/JanusGraph.Net.csproj
+++ b/src/JanusGraph.Net/JanusGraph.Net.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSource>True</IncludeSource>
@@ -25,7 +25,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0 " PrivateAssets="All"/>
-    <PackageReference Include="Gremlin.Net" Version="3.4.6" />
+    <PackageReference Include="Gremlin.Net" Version="3.5.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\JanusGraph logomark color RGB.png" Pack="true" PackagePath="\"/>

--- a/src/JanusGraph.Net/JanusGraphClientBuilder.cs
+++ b/src/JanusGraph.Net/JanusGraphClientBuilder.cs
@@ -86,8 +86,9 @@ namespace JanusGraph.Net
         /// </summary>
         public IGremlinClient Create()
         {
-            return new GremlinClient(_server, _readerBuilder.Create(), _writerBuilder.Create(),
-                connectionPoolSettings: _connectionPoolSettings);
+            return new GremlinClient(_server,
+                new GraphSON3MessageSerializer(_readerBuilder.Create(), _writerBuilder.Create()),
+                _connectionPoolSettings);
         }
     }
 }

--- a/test/JanusGraph.Net.UnitTest/IO/GraphSON/GeoshapeDeserializerTests.cs
+++ b/test/JanusGraph.Net.UnitTest/IO/GraphSON/GeoshapeDeserializerTests.cs
@@ -20,9 +20,9 @@
 
 using System;
 using System.Globalization;
+using System.Text.Json;
 using JanusGraph.Net.Geoshapes;
 using JanusGraph.Net.IO.GraphSON;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace JanusGraph.Net.UnitTest.IO.GraphSON
@@ -39,7 +39,7 @@ namespace JanusGraph.Net.UnitTest.IO.GraphSON
                             latitude.ToString(CultureInfo.InvariantCulture) + "]}}";
             var reader = JanusGraphSONReaderBuilder.Build().Create();
 
-            var readPoint = reader.ToObject(JToken.Parse(graphSon));
+            var readPoint = reader.ToObject(JsonDocument.Parse(graphSon).RootElement);
 
             var expectedPoint = Geoshape.Point(latitude, longitude);
             Assert.Equal(expectedPoint, readPoint);
@@ -52,7 +52,7 @@ namespace JanusGraph.Net.UnitTest.IO.GraphSON
                 "{\"@type\":\"janusgraph:Geoshape\",\"@value\":{\"geometry\":{\"type\":\"Unknown\"}}}";
             var reader = JanusGraphSONReaderBuilder.Build().Create();
 
-            Assert.Throws<InvalidOperationException>(() => reader.ToObject(JToken.Parse(graphSon)));
+            Assert.Throws<InvalidOperationException>(() => reader.ToObject(JsonDocument.Parse(graphSon).RootElement));
         }
     }
 }

--- a/test/JanusGraph.Net.UnitTest/IO/GraphSON/GeoshapeSerializationSymmetricyTests.cs
+++ b/test/JanusGraph.Net.UnitTest/IO/GraphSON/GeoshapeSerializationSymmetricyTests.cs
@@ -18,9 +18,9 @@
 
 #endregion
 
+using System.Text.Json;
 using JanusGraph.Net.Geoshapes;
 using JanusGraph.Net.IO.GraphSON;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace JanusGraph.Net.UnitTest.IO.GraphSON
@@ -35,7 +35,7 @@ namespace JanusGraph.Net.UnitTest.IO.GraphSON
             var reader = JanusGraphSONReaderBuilder.Build().Create();
 
             var graphSon = writer.WriteObject(point);
-            var readPoint = reader.ToObject(JToken.Parse(graphSon));
+            var readPoint = reader.ToObject(JsonDocument.Parse(graphSon).RootElement);
 
             Assert.Equal(point, readPoint);
         }

--- a/test/JanusGraph.Net.UnitTest/IO/GraphSON/GraphSONReaderBuilderTests.cs
+++ b/test/JanusGraph.Net.UnitTest/IO/GraphSON/GraphSONReaderBuilderTests.cs
@@ -18,9 +18,9 @@
 
 #endregion
 
+using System.Text.Json;
 using Gremlin.Net.Structure.IO.GraphSON;
 using JanusGraph.Net.IO.GraphSON;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace JanusGraph.Net.UnitTest.IO.GraphSON
@@ -39,14 +39,14 @@ namespace JanusGraph.Net.UnitTest.IO.GraphSON
 
             var reader = JanusGraphSONReaderBuilder.Build().RegisterDeserializer(graphSONType, customDeserializer).Create();
 
-            Assert.Equal(deserializationResult, reader.ToObject(JToken.Parse(graphSon)));
+            Assert.Equal(deserializationResult, reader.ToObject(JsonDocument.Parse(graphSon).RootElement));
         }
 
         private class DeserializerFake : IGraphSONDeserializer
         {
             public object DeserializationResult { get; set; }
 
-            public dynamic Objectify(JToken graphsonObject, GraphSONReader reader)
+            public dynamic Objectify(JsonElement graphsonObject, GraphSONReader reader)
             {
                 return DeserializationResult;
             }

--- a/test/JanusGraph.Net.UnitTest/IO/GraphSON/GraphSONWriterBuilderTests.cs
+++ b/test/JanusGraph.Net.UnitTest/IO/GraphSON/GraphSONWriterBuilderTests.cs
@@ -19,10 +19,10 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Text.Json;
 using Gremlin.Net.Structure.IO.GraphSON;
 using JanusGraph.Net.Geoshapes;
 using JanusGraph.Net.IO.GraphSON;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace JanusGraph.Net.UnitTest.IO.GraphSON
@@ -56,7 +56,7 @@ namespace JanusGraph.Net.UnitTest.IO.GraphSON
 
         private class SerializerFake : IGraphSONSerializer
         {
-            public string DeserializationResult => JsonConvert.SerializeObject(_typedValue);
+            public string DeserializationResult => JsonSerializer.Serialize(_typedValue);
             private readonly Dictionary<string, dynamic> _typedValue;
 
             private SerializerFake(string graphSonType, object valueToReturn)
@@ -66,7 +66,7 @@ namespace JanusGraph.Net.UnitTest.IO.GraphSON
 
             public static SerializerFake Register(string graphSonType, object valueToReturn)
             {
-                return new SerializerFake(graphSonType, valueToReturn);
+                return new(graphSonType, valueToReturn);
             }
 
             public Dictionary<string, dynamic> Dictify(dynamic objectData, GraphSONWriter writer)

--- a/test/JanusGraph.Net.UnitTest/IO/GraphSON/RelationIdentifierDeserializerTests.cs
+++ b/test/JanusGraph.Net.UnitTest/IO/GraphSON/RelationIdentifierDeserializerTests.cs
@@ -18,8 +18,8 @@
 
 #endregion
 
+using System.Text.Json;
 using JanusGraph.Net.IO.GraphSON;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace JanusGraph.Net.UnitTest.IO.GraphSON
@@ -33,7 +33,7 @@ namespace JanusGraph.Net.UnitTest.IO.GraphSON
                 "{\"@type\":\"janusgraph:RelationIdentifier\",\"@value\":{\"relationId\":\"3k1-360-6c5-39c\"}}";
             var reader = JanusGraphSONReaderBuilder.Build().Create();
 
-            var readRelationIdentifier = reader.ToObject(JToken.Parse(graphSon));
+            var readRelationIdentifier = reader.ToObject(JsonDocument.Parse(graphSon).RootElement);
 
             var expectedRelationIdentifier = new RelationIdentifier("3k1-360-6c5-39c");
             Assert.Equal(expectedRelationIdentifier, readRelationIdentifier);

--- a/test/JanusGraph.Net.UnitTest/IO/GraphSON/RelationIdentifierSerializationSymmetricyTests.cs
+++ b/test/JanusGraph.Net.UnitTest/IO/GraphSON/RelationIdentifierSerializationSymmetricyTests.cs
@@ -18,8 +18,8 @@
 
 #endregion
 
+using System.Text.Json;
 using JanusGraph.Net.IO.GraphSON;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace JanusGraph.Net.UnitTest.IO.GraphSON
@@ -34,7 +34,7 @@ namespace JanusGraph.Net.UnitTest.IO.GraphSON
             var reader = JanusGraphSONReaderBuilder.Build().Create();
 
             var graphSon = writer.WriteObject(relationIdentifier);
-            var readRelationIdentifier = reader.ToObject(JToken.Parse(graphSon));
+            var readRelationIdentifier = reader.ToObject(JsonDocument.Parse(graphSon).RootElement);
 
             Assert.Equal(relationIdentifier, readRelationIdentifier);
         }


### PR DESCRIPTION
Gremlin.Net 3.5.0 switched the JSON library to System.Text.Json and
introduced a new IMessageSerializer.

Part of #59