### PR TITLE
0.4.1 Release

### DIFF
--- a/src/JanusGraph.Net/JanusGraph.Net.csproj
+++ b/src/JanusGraph.Net/JanusGraph.Net.csproj
@@ -6,7 +6,7 @@
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
     <Title>JanusGraph.Net</Title>
     <Authors>JanusGraph</Authors>
     <Description>


### PR DESCRIPTION
This release mostly updates Gremlin.Net to 3.5.3 which is also the TinkerPop version used by JanusGraph 0.6.2.

Gremlin.Net 3.5.3 adds support for WebSocket Compression which is also enabled by default:
https://tinkerpop.apache.org/docs/3.5.3/upgrade/#_net_websocket_compression_support