### PR TITLE
Enable Dependabot also for GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,10 @@ updates:
     interval: daily
     time: "11:00"
   open-pull-requests-limit: 10
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,6 +16,8 @@ name: .NET
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
   release:
     types:


### PR DESCRIPTION
Fixes #114

CI is disable for Dependabot pushes, but still enabled for all PRs to avoid unnecessarily building all Dependabot changes twice.