### PR TITLE
0.4.2 Release

### DIFF
--- a/src/JanusGraph.Net/JanusGraph.Net.csproj
+++ b/src/JanusGraph.Net/JanusGraph.Net.csproj
@@ -6,7 +6,7 @@
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>0.4.1</Version>
+    <Version>0.4.2</Version>
     <Title>JanusGraph.Net</Title>
     <Authors>JanusGraph</Authors>
     <Description>


### PR DESCRIPTION
The main change in this release is the deprecation of the `JanusGraphClientBuilder`.
The reasoning behind this deprecation is mostly that the builder makes it harder to configure the `GremlinClient` as it needs to replicate all config options. Showing users how they can just configure a `GremlinClient` with serialization support for JanusGraph also makes it easier to use this library for existing users of Gremlin.Net.

More information can be found in this issue: #112

I intend to add JanusGraph.Net finally [to the main JanusGraph docs](https://docs.janusgraph.org/interactions/connecting/dotnet/) after 0.4.2 is released as I expect the API to stay mostly stable now.