### PR TITLE
Update Testcontainers to version 2.4.0

### DIFF
--- a/test/JanusGraph.Net.IntegrationTest/JanusGraph.Net.IntegrationTest.csproj
+++ b/test/JanusGraph.Net.IntegrationTest/JanusGraph.Net.IntegrationTest.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Testcontainers" Version="2.3.0" />
+    <PackageReference Include="Testcontainers" Version="2.4.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/test/JanusGraph.Net.IntegrationTest/JanusGraphServerFixture.cs
+++ b/test/JanusGraph.Net.IntegrationTest/JanusGraphServerFixture.cs
@@ -34,17 +34,17 @@ namespace JanusGraph.Net.IntegrationTest
 {
     public class JanusGraphServerFixture : IAsyncLifetime
     {
-        private readonly TestcontainersContainer _container;
+        private readonly IContainer _container;
         private const ushort JanusGraphServerPort = 8182;
 
         public JanusGraphServerFixture()
         {
             var config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
             var dockerImage = config["dockerImage"];
-            _container = new TestcontainersBuilder<TestcontainersContainer>()
+            _container = new ContainerBuilder()
                 .WithImage(dockerImage)
                 .WithName("janusgraph")
-                .WithPortBinding(JanusGraphServerPort)
+                .WithPortBinding(JanusGraphServerPort, true)
                 .WithBindMount($"{AppContext.BaseDirectory}/load_data.groovy",
                     "/docker-entrypoint-initdb.d/load_data.groovy", AccessMode.ReadOnly)
                 .WithWaitStrategy(Wait.ForUnixContainer().UntilOperationIsSucceeded(IsServerReady, 1000))


### PR DESCRIPTION
This update comes with a few small breaking changes where APIs were deprecated. These changes are documented here:
https://www.atomicjar.com/2023/02/testcontainers-for-dotnet-2-4-0/