### PR TITLE
Update Gremlin.Net to 3.5.5 for JanusGraph 0.6.3

### DIFF
--- a/src/JanusGraph.Net/IO/GraphBinary/Types/JanusGraphPSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/JanusGraphPSerializer.cs
@@ -19,6 +19,7 @@
 #endregion
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Structure.IO.GraphBinary;
 
@@ -31,16 +32,18 @@ namespace JanusGraph.Net.IO.GraphBinary.Types
         }
 
         protected override async Task WriteNonNullableValueAsync(JanusGraphP value, Stream stream,
-            GraphBinaryWriter writer)
+            GraphBinaryWriter writer, CancellationToken cancellationToken = default)
         {
-            await writer.WriteValueAsync(value.OperatorName, stream, false).ConfigureAwait(false);
-            await writer.WriteAsync(value.Value, stream).ConfigureAwait(false);
+            await writer.WriteValueAsync(value.OperatorName, stream, false, cancellationToken).ConfigureAwait(false);
+            await writer.WriteAsync(value.Value, stream, cancellationToken).ConfigureAwait(false);
         }
 
-        protected override async Task<JanusGraphP> ReadNonNullableValueAsync(Stream stream, GraphBinaryReader reader)
+        protected override async Task<JanusGraphP> ReadNonNullableValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
         {
-            var operatorName = (string)await reader.ReadValueAsync<string>(stream, false).ConfigureAwait(false);
-            var value = await reader.ReadAsync(stream).ConfigureAwait(false);
+            var operatorName = (string)await reader.ReadValueAsync<string>(stream, false, cancellationToken)
+                .ConfigureAwait(false);
+            var value = await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
             return new JanusGraphP(operatorName, value);
         }
     }

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/RelationIdentifierSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/RelationIdentifierSerializer.cs
@@ -19,6 +19,7 @@
 #endregion
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Structure.IO.GraphBinary;
 
@@ -31,21 +32,21 @@ namespace JanusGraph.Net.IO.GraphBinary.Types
         }
 
         protected override async Task WriteNonNullableValueAsync(RelationIdentifier value, Stream stream,
-            GraphBinaryWriter writer)
+            GraphBinaryWriter writer, CancellationToken cancellationToken = default)
         {
-            await stream.WriteLongAsync(value.OutVertexId).ConfigureAwait(false);
-            await stream.WriteLongAsync(value.TypeId).ConfigureAwait(false);
-            await stream.WriteLongAsync(value.RelationId).ConfigureAwait(false);
-            await stream.WriteLongAsync(value.InVertexId).ConfigureAwait(false);
+            await stream.WriteLongAsync(value.OutVertexId, cancellationToken).ConfigureAwait(false);
+            await stream.WriteLongAsync(value.TypeId, cancellationToken).ConfigureAwait(false);
+            await stream.WriteLongAsync(value.RelationId, cancellationToken).ConfigureAwait(false);
+            await stream.WriteLongAsync(value.InVertexId, cancellationToken).ConfigureAwait(false);
         }
 
         protected override async Task<RelationIdentifier> ReadNonNullableValueAsync(Stream stream,
-            GraphBinaryReader reader)
+            GraphBinaryReader reader, CancellationToken cancellationToken = default)
         {
-            var outVertexId = await stream.ReadLongAsync().ConfigureAwait(false);
-            var typeId = await stream.ReadLongAsync().ConfigureAwait(false);
-            var relationId = await stream.ReadLongAsync().ConfigureAwait(false);
-            var inVertexId = await stream.ReadLongAsync().ConfigureAwait(false);
+            var outVertexId = await stream.ReadLongAsync(cancellationToken).ConfigureAwait(false);
+            var typeId = await stream.ReadLongAsync(cancellationToken).ConfigureAwait(false);
+            var relationId = await stream.ReadLongAsync(cancellationToken).ConfigureAwait(false);
+            var inVertexId = await stream.ReadLongAsync(cancellationToken).ConfigureAwait(false);
             return new RelationIdentifier(outVertexId, typeId, relationId, inVertexId);
         }
     }

--- a/src/JanusGraph.Net/IO/GraphSON/JanusGraphGraphSONMessageSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphSON/JanusGraphGraphSONMessageSerializer.cs
@@ -19,6 +19,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Gremlin.Net.Driver;
 using Gremlin.Net.Driver.Messages;
@@ -66,15 +67,17 @@ namespace JanusGraph.Net.IO.GraphSON
         }
 
         /// <inheritdoc />
-        public async Task<byte[]> SerializeMessageAsync(RequestMessage requestMessage)
+        public async Task<byte[]> SerializeMessageAsync(RequestMessage requestMessage,
+            CancellationToken cancellationToken = default)
         {
-            return await _serializer.SerializeMessageAsync(requestMessage).ConfigureAwait(false);
+            return await _serializer.SerializeMessageAsync(requestMessage, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<ResponseMessage<List<object>>> DeserializeMessageAsync(byte[] message)
+        public async Task<ResponseMessage<List<object>>> DeserializeMessageAsync(byte[] message,
+            CancellationToken cancellationToken = default)
         {
-            return await _serializer.DeserializeMessageAsync(message).ConfigureAwait(false);
+            return await _serializer.DeserializeMessageAsync(message, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/JanusGraph.Net/JanusGraph.Net.csproj
+++ b/src/JanusGraph.Net/JanusGraph.Net.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1 " PrivateAssets="All"/>
-    <PackageReference Include="Gremlin.Net" Version="3.5.3" />
+    <PackageReference Include="Gremlin.Net" Version="3.5.5" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\JanusGraph logomark color RGB.png" Pack="true" PackagePath="\" />


### PR DESCRIPTION
Notable changes in Gremlin.Net:
* Async tasks can be cancelled.
* Logging support: https://tinkerpop.apache.org/docs/current/upgrade/#_gremlin_net_add_logging

I plan to release 0.4.3 shortly after merging this.