### PR TITLE
0.4.3 Release

### DIFF
--- a/src/JanusGraph.Net/JanusGraph.Net.csproj
+++ b/src/JanusGraph.Net/JanusGraph.Net.csproj
@@ -6,7 +6,7 @@
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>0.4.2</Version>
+    <Version>0.4.3</Version>
     <Title>JanusGraph.Net</Title>
     <Authors>JanusGraph</Authors>
     <Description>


### PR DESCRIPTION
This release updates Gremlin.Net to version 3.5.5 which is the version used by JanusGraph 0.6.3.
Notable changes coming with this update are:
* Async tasks can be cancelled.
* Logging support: https://tinkerpop.apache.org/docs/current/upgrade/#_gremlin_net_add_logging