### PR TITLE
Support JanusGraph 1.0.0

### DIFF
--- a/src/JanusGraph.Net/IO/GraphSON/JanusGraphGraphSONMessageSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphSON/JanusGraphGraphSONMessageSerializer.cs
@@ -52,20 +52,6 @@ namespace JanusGraph.Net.IO.GraphSON
         {
         }
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="JanusGraphGraphSONMessageSerializer" /> class.
-        /// </summary>
-        /// <param name="janusGraphPredicates">
-        ///     This value activates support for JanusGraph predicate serialization added in
-        ///     JanusGraph 0.6.0. It should be set to true for JanusGraph Server versions >= 0.6.0 and to false for versions before
-        ///     0.6.0.
-        /// </param>
-        public JanusGraphGraphSONMessageSerializer(bool janusGraphPredicates)
-            : this(JanusGraphSONReaderBuilder.Build().Create(),
-                JanusGraphSONWriterBuilder.Build(janusGraphPredicates).Create())
-        {
-        }
-
         /// <inheritdoc />
         public async Task<byte[]> SerializeMessageAsync(RequestMessage requestMessage,
             CancellationToken cancellationToken = default)

--- a/src/JanusGraph.Net/IO/GraphSON/JanusGraphSONWriterBuilder.cs
+++ b/src/JanusGraph.Net/IO/GraphSON/JanusGraphSONWriterBuilder.cs
@@ -33,17 +33,14 @@ namespace JanusGraph.Net.IO.GraphSON
     {
         private readonly Dictionary<Type, IGraphSONSerializer> _serializerByType;
 
-        private JanusGraphSONWriterBuilder(bool janusGraphPredicates)
+        private JanusGraphSONWriterBuilder()
         {
             _serializerByType = new Dictionary<Type, IGraphSONSerializer>
             {
-                {typeof(Point), new PointSerializer()},
-                {typeof(RelationIdentifier), new RelationIdentifierSerializer()},
+                { typeof(Point), new PointSerializer() },
+                { typeof(RelationIdentifier), new RelationIdentifierSerializer() },
+                { typeof(JanusGraphP), new JanusGraphPSerializer() }
             };
-            if (janusGraphPredicates)
-            {
-                _serializerByType.Add(typeof(JanusGraphP), new JanusGraphPSerializer());
-            }
         }
 
         /// <summary>
@@ -51,20 +48,7 @@ namespace JanusGraph.Net.IO.GraphSON
         /// </summary>
         public static JanusGraphSONWriterBuilder Build()
         {
-            return new JanusGraphSONWriterBuilder(true);
-        }
-
-        /// <summary>
-        ///     Initializes a <see cref="JanusGraphSONWriterBuilder" />.
-        /// </summary>
-        /// <param name="janusGraphPredicates">
-        ///     This value activates support for JanusGraph predicate serialization added in
-        ///     JanusGraph 0.6.0. It should be set to true for JanusGraph Server versions >= 0.6.0 and to false for versions before
-        ///     0.6.0.
-        /// </param>
-        public static JanusGraphSONWriterBuilder Build(bool janusGraphPredicates)
-        {
-            return new JanusGraphSONWriterBuilder(janusGraphPredicates);
+            return new JanusGraphSONWriterBuilder();
         }
 
         /// <summary>

--- a/src/JanusGraph.Net/JanusGraph.Net.csproj
+++ b/src/JanusGraph.Net/JanusGraph.Net.csproj
@@ -22,8 +22,8 @@
     <PackageIconUrl>https://raw.githubusercontent.com/JanusGraph/logos/master/RGB%20-%20PNG%20small/JanusGraph%20logomark%20color%20RGB.png</PackageIconUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1 " PrivateAssets="All"/>
-    <PackageReference Include="Gremlin.Net" Version="3.5.5" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Gremlin.Net" Version="3.6.2" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\JanusGraph logomark color RGB.png" Pack="true" PackagePath="\" />

--- a/src/JanusGraph.Net/JanusGraphClientBuilder.cs
+++ b/src/JanusGraph.Net/JanusGraphClientBuilder.cs
@@ -40,10 +40,10 @@ namespace JanusGraph.Net
         private IMessageSerializer _serializer;
         private ConnectionPoolSettings _connectionPoolSettings;
 
-        private JanusGraphClientBuilder(GremlinServer server, bool janusGraphPredicates)
+        private JanusGraphClientBuilder(GremlinServer server)
         {
             _server = server;
-            _writerBuilder = JanusGraphSONWriterBuilder.Build(janusGraphPredicates);
+            _writerBuilder = JanusGraphSONWriterBuilder.Build();
         }
 
         /// <summary>
@@ -52,20 +52,7 @@ namespace JanusGraph.Net
         /// <param name="server">The <see cref="GremlinServer" /> requests should be sent to.</param>
         public static JanusGraphClientBuilder BuildClientForServer(GremlinServer server)
         {
-            return new JanusGraphClientBuilder(server, true);
-        }
-
-        /// <summary>
-        ///     Initializes a <see cref="JanusGraphClientBuilder" /> for the given <see cref="GremlinServer" />.
-        /// </summary>
-        /// <param name="server">The <see cref="GremlinServer" /> requests should be sent to.</param>
-        /// <param name="janusGraphPredicates">
-        ///     This value activates support for JanusGraph predicate serialization added in JanusGraph 0.6.0. It should be set to
-        ///     true for JanusGraph Server versions >= 0.6.0 and to false for versions before 0.6.0.
-        /// </param>
-        public static JanusGraphClientBuilder BuildClientForServer(GremlinServer server, bool janusGraphPredicates)
-        {
-            return new JanusGraphClientBuilder(server, janusGraphPredicates);
+            return new JanusGraphClientBuilder(server);
         }
 
         /// <summary>

--- a/test/JanusGraph.Net.UnitTest/IO/GraphSON/GraphSONWriterBuilderTests.cs
+++ b/test/JanusGraph.Net.UnitTest/IO/GraphSON/GraphSONWriterBuilderTests.cs
@@ -20,7 +20,6 @@
 
 using System.Collections.Generic;
 using System.Text.Json;
-using Gremlin.Net.Process.Traversal;
 using Gremlin.Net.Structure.IO.GraphSON;
 using JanusGraph.Net.Geoshapes;
 using JanusGraph.Net.IO.GraphSON;
@@ -53,30 +52,6 @@ namespace JanusGraph.Net.UnitTest.IO.GraphSON
                 .Create();
 
             Assert.Equal(customSerializer.DeserializationResult, writer.WriteObject(Geoshape.Point(1, 2)));
-        }
-
-        [Fact]
-        public void Build_DisabledJanusGraphPredicates_UsesTinkerPopPredicateSerializationForJanusGraphPredicate()
-        {
-            var janusgraphPredicate = Text.TextContainsFuzzy("test");
-            var tinkerpopPredicate = new P(janusgraphPredicate.OperatorName, janusgraphPredicate.Value);
-
-            // ReSharper disable once RedundantArgumentDefaultValue
-            var writer = JanusGraphSONWriterBuilder.Build(false).Create();
-
-            Assert.Equal(writer.WriteObject(tinkerpopPredicate), writer.WriteObject(janusgraphPredicate));
-        }
-
-        [Fact]
-        public void Build_EnabledJanusGraphPredicates_UsesJanusGraphPredicateSerializationForJanusGraphPredicate()
-        {
-            var janusgraphPredicate = Text.TextContainsFuzzy("test");
-
-            var writer = JanusGraphSONWriterBuilder.Build(true).Create();
-
-            const string janusgraphPredicateGraphSon =
-                "{\"@type\":\"janusgraph:JanusGraphP\",\"@value\":{\"predicate\":\"textContainsFuzzy\",\"value\":\"test\"}}";
-            Assert.Equal(janusgraphPredicateGraphSon, writer.WriteObject(janusgraphPredicate));
         }
 
         private class SerializerFake : IGraphSONSerializer


### PR DESCRIPTION
This updates Gremlin.Net to 3.6.2 and removes a fallback for an outdated serialization of JanusGraph predicates which was also removed in JanusGraph 1.0.0:
https://docs.janusgraph.org/master/changelog/#remove-support-for-old-serialization-format-of-janusgraph-predicates

This could also been split into two separate PRs for these two issues, but I've figured that it's easier to review together in one. They can still be reviewed separately as I've created two commits.

Part of #125