### PR TITLE
Initial Geoshapes support for GraphBinary

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,10 @@ Not all of the JanusGraph-specific types are already supported by both formats:
 | Format      | RelationIdentifier | Text predicates | Geoshapes | Geo predicates |
 | ----------- | ------------------ | --------------- | --------- | -------------- |
 | GraphSON3   | x                  | x               | `Point`   | -              |
-| GraphBinary | x                  | x               | -         | -              |
+| GraphBinary | x                  | x               | `Point`*  | -              |
+
+\* Since version 1.0.0 of JanusGraph.Net.
+JanusGraph also needs to be on version 1.0.0 or higher.
 
 ## Community
 

--- a/src/JanusGraph.Net/IO/GraphBinary/JanusGraphTypeSerializerRegistry.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/JanusGraphTypeSerializerRegistry.cs
@@ -21,6 +21,7 @@
 using System;
 using Gremlin.Net.Structure.IO.GraphBinary;
 using Gremlin.Net.Structure.IO.GraphBinary.Types;
+using JanusGraph.Net.Geoshapes;
 using JanusGraph.Net.IO.GraphBinary.Types;
 
 namespace JanusGraph.Net.IO.GraphBinary
@@ -48,6 +49,7 @@ namespace JanusGraph.Net.IO.GraphBinary
             {
                 _builder.AddCustomType(typeof(RelationIdentifier), new RelationIdentifierSerializer());
                 _builder.AddCustomType(typeof(JanusGraphP), new JanusGraphPSerializer());
+                _builder.AddCustomType(typeof(Point), new GeoshapeSerializer());
             }
 
             /// <summary>

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/GeoshapeConstants.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/GeoshapeConstants.cs
@@ -1,0 +1,30 @@
+﻿#region License
+
+/*
+ * Copyright 2023 JanusGraph.Net Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+namespace JanusGraph.Net.IO.GraphBinary.Types
+{
+    internal static class GeoshapeConstants
+    {
+        public const byte GeoshapeFormatVersion = 2;
+
+        // Geoshape type codes
+        public const int GeoshapePointTypeCode = 0;
+    }
+}

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/GeoshapeSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/GeoshapeSerializer.cs
@@ -1,0 +1,82 @@
+﻿#region License
+
+/*
+ * Copyright 2023 JanusGraph.Net Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Gremlin.Net.Structure.IO.GraphBinary;
+using JanusGraph.Net.Geoshapes;
+
+namespace JanusGraph.Net.IO.GraphBinary.Types
+{
+    internal class GeoshapeSerializer : JanusGraphTypeSerializer
+    {
+        private readonly Dictionary<Type, GeoshapeTypeSerializer> _serializerByType =
+            new Dictionary<Type, GeoshapeTypeSerializer>
+            {
+                { typeof(Point), new PointSerializer() }
+            };
+
+        private readonly Dictionary<int, GeoshapeTypeSerializer> _serializerByGeoshapeTypeCode =
+            new Dictionary<int, GeoshapeTypeSerializer>
+            {
+                { GeoshapeConstants.GeoshapePointTypeCode, new PointSerializer() }
+            };
+
+        public GeoshapeSerializer() : base(GraphBinaryType.Geoshape)
+        {
+        }
+
+        protected override async Task WriteNonNullableValueAsync(object value, Stream stream, GraphBinaryWriter writer,
+            CancellationToken cancellationToken = default)
+        {
+            await stream.WriteByteAsync(GeoshapeConstants.GeoshapeFormatVersion, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!_serializerByType.TryGetValue(value.GetType(), out var serializer))
+            {
+                throw new IOException($"Geoshape type {value.GetType()} not supported");
+            }
+
+            await serializer.WriteNonNullableValueAsync(value, stream, writer, cancellationToken).ConfigureAwait(false);
+        }
+
+        protected override async Task<object> ReadNonNullableValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken = default)
+        {
+            var formatVersion = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
+            if (formatVersion != GeoshapeConstants.GeoshapeFormatVersion)
+            {
+                throw new IOException($"Geoshape format {formatVersion} not supported");
+            }
+
+            var geoshapeTypeCode = await stream.ReadIntAsync(cancellationToken).ConfigureAwait(false);
+            if (!_serializerByGeoshapeTypeCode.TryGetValue(geoshapeTypeCode, out var serializer))
+            {
+                throw new IOException($"Geoshape type code {geoshapeTypeCode} not supported");
+            }
+
+            return await serializer.ReadNonNullableGeoshapeValueAsync(stream, reader, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/GeoshapeTypeSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/GeoshapeTypeSerializer.cs
@@ -1,0 +1,52 @@
+﻿#region License
+
+/*
+ * Copyright 2023 JanusGraph.Net Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Gremlin.Net.Structure.IO.GraphBinary;
+
+namespace JanusGraph.Net.IO.GraphBinary.Types
+{
+    internal abstract class GeoshapeTypeSerializer
+    {
+        private readonly int _geoshapeTypeCode;
+
+        protected GeoshapeTypeSerializer(int geoshapeTypeCode)
+        {
+            _geoshapeTypeCode = geoshapeTypeCode;
+        }
+
+        public async Task WriteNonNullableValueAsync(object geoshape, Stream stream,
+            GraphBinaryWriter writer, CancellationToken cancellationToken = default)
+        {
+            await stream.WriteIntAsync(_geoshapeTypeCode, cancellationToken)
+                .ConfigureAwait(false);
+
+            await WriteNonNullableGeoshapeValueAsync(geoshape, stream, writer, cancellationToken).ConfigureAwait(false);
+        }
+
+        protected abstract Task WriteNonNullableGeoshapeValueAsync(object geoshape, Stream stream,
+            GraphBinaryWriter writer, CancellationToken cancellationToken);
+
+        public abstract Task<object> ReadNonNullableGeoshapeValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/GraphBinaryType.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/GraphBinaryType.cs
@@ -25,6 +25,9 @@ namespace JanusGraph.Net.IO.GraphBinary.Types
     /// </summary>
     public class GraphBinaryType
     {
+        internal static readonly GraphBinaryType Geoshape =
+            new GraphBinaryType(0x1000, "janusgraph.Geoshape");
+
         internal static readonly GraphBinaryType RelationIdentifier =
             new GraphBinaryType(0x1001, "janusgraph.RelationIdentifier");
 

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/JanusGraphPSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/JanusGraphPSerializer.cs
@@ -25,20 +25,21 @@ using Gremlin.Net.Structure.IO.GraphBinary;
 
 namespace JanusGraph.Net.IO.GraphBinary.Types
 {
-    internal class JanusGraphPSerializer : JanusGraphTypeSerializer<JanusGraphP>
+    internal class JanusGraphPSerializer : JanusGraphTypeSerializer
     {
         public JanusGraphPSerializer() : base(GraphBinaryType.JanusGraphP)
         {
         }
 
-        protected override async Task WriteNonNullableValueAsync(JanusGraphP value, Stream stream,
+        protected override async Task WriteNonNullableValueAsync(object value, Stream stream,
             GraphBinaryWriter writer, CancellationToken cancellationToken = default)
         {
-            await writer.WriteValueAsync(value.OperatorName, stream, false, cancellationToken).ConfigureAwait(false);
-            await writer.WriteAsync(value.Value, stream, cancellationToken).ConfigureAwait(false);
+            var p = (JanusGraphP)value;
+            await writer.WriteValueAsync(p.OperatorName, stream, false, cancellationToken).ConfigureAwait(false);
+            await writer.WriteAsync(p.Value, stream, cancellationToken).ConfigureAwait(false);
         }
 
-        protected override async Task<JanusGraphP> ReadNonNullableValueAsync(Stream stream, GraphBinaryReader reader,
+        protected override async Task<object> ReadNonNullableValueAsync(Stream stream, GraphBinaryReader reader,
             CancellationToken cancellationToken = default)
         {
             var operatorName = (string)await reader.ReadValueAsync<string>(stream, false, cancellationToken)

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/JanusGraphTypeSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/JanusGraphTypeSerializer.cs
@@ -29,13 +29,12 @@ namespace JanusGraph.Net.IO.GraphBinary.Types
     /// <summary>
     ///     Base class for GraphBinary serializers of JanusGraph types.
     /// </summary>
-    /// <typeparam name="T">The JanusGraph type to be serialized.</typeparam>
-    public abstract class JanusGraphTypeSerializer<T> : CustomTypeSerializer
+    public abstract class JanusGraphTypeSerializer : CustomTypeSerializer
     {
         private readonly GraphBinaryType _type;
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="JanusGraphTypeSerializer{T}" /> class.
+        ///     Initializes a new instance of the <see cref="JanusGraphTypeSerializer" /> class.
         /// </summary>
         /// <param name="type">The GraphBinaryType for this serializer.</param>
         protected JanusGraphTypeSerializer(GraphBinaryType type)
@@ -72,7 +71,7 @@ namespace JanusGraph.Net.IO.GraphBinary.Types
                 await writer.WriteValueFlagNoneAsync(stream, cancellationToken).ConfigureAwait(false);
             }
 
-            await WriteNonNullableValueAsync((T) value, stream, writer, cancellationToken).ConfigureAwait(false);
+            await WriteNonNullableValueAsync(value, stream, writer, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -83,7 +82,7 @@ namespace JanusGraph.Net.IO.GraphBinary.Types
         /// <param name="writer">A <see cref="GraphBinaryWriter"/> that can be used to write nested values.</param>
         /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        protected abstract Task WriteNonNullableValueAsync(T value, Stream stream, GraphBinaryWriter writer,
+        protected abstract Task WriteNonNullableValueAsync(object value, Stream stream, GraphBinaryWriter writer,
             CancellationToken cancellationToken = default);
 
         /// <inheritdoc />
@@ -123,7 +122,7 @@ namespace JanusGraph.Net.IO.GraphBinary.Types
         /// <param name="reader">A <see cref="GraphBinaryReader"/> that can be used to read nested values.</param>
         /// <param name="cancellationToken">The token to cancel the operation. The default value is None.</param>
         /// <returns>The read value.</returns>
-        protected abstract Task<T> ReadNonNullableValueAsync(Stream stream, GraphBinaryReader reader,
+        protected abstract Task<object> ReadNonNullableValueAsync(Stream stream, GraphBinaryReader reader,
             CancellationToken cancellationToken = default);
 
         /// <inheritdoc />

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/PointSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/PointSerializer.cs
@@ -1,0 +1,51 @@
+﻿#region License
+
+/*
+ * Copyright 2023 JanusGraph.Net Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Gremlin.Net.Structure.IO.GraphBinary;
+using JanusGraph.Net.Geoshapes;
+
+namespace JanusGraph.Net.IO.GraphBinary.Types
+{
+    internal class PointSerializer : GeoshapeTypeSerializer
+    {
+        public PointSerializer() : base(GeoshapeConstants.GeoshapePointTypeCode)
+        {
+        }
+
+        protected override async Task WriteNonNullableGeoshapeValueAsync(object geoshape, Stream stream,
+            GraphBinaryWriter writer, CancellationToken cancellationToken)
+        {
+            var point = (Point)geoshape;
+            await stream.WriteDoubleAsync(point.Latitude, cancellationToken).ConfigureAwait(false);
+            await stream.WriteDoubleAsync(point.Longitude, cancellationToken).ConfigureAwait(false);
+        }
+
+        public override async Task<object> ReadNonNullableGeoshapeValueAsync(Stream stream, GraphBinaryReader reader,
+            CancellationToken cancellationToken)
+        {
+            var latitude = await stream.ReadDoubleAsync(cancellationToken).ConfigureAwait(false);
+            var longitude = await stream.ReadDoubleAsync(cancellationToken).ConfigureAwait(false);
+            return new Point(latitude, longitude);
+        }
+    }
+}

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/RelationIdentifierSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/RelationIdentifierSerializer.cs
@@ -25,22 +25,23 @@ using Gremlin.Net.Structure.IO.GraphBinary;
 
 namespace JanusGraph.Net.IO.GraphBinary.Types
 {
-    internal class RelationIdentifierSerializer : JanusGraphTypeSerializer<RelationIdentifier>
+    internal class RelationIdentifierSerializer : JanusGraphTypeSerializer
     {
         public RelationIdentifierSerializer() : base(GraphBinaryType.RelationIdentifier)
         {
         }
 
-        protected override async Task WriteNonNullableValueAsync(RelationIdentifier value, Stream stream,
+        protected override async Task WriteNonNullableValueAsync(object value, Stream stream,
             GraphBinaryWriter writer, CancellationToken cancellationToken = default)
         {
-            await stream.WriteLongAsync(value.OutVertexId, cancellationToken).ConfigureAwait(false);
-            await stream.WriteLongAsync(value.TypeId, cancellationToken).ConfigureAwait(false);
-            await stream.WriteLongAsync(value.RelationId, cancellationToken).ConfigureAwait(false);
-            await stream.WriteLongAsync(value.InVertexId, cancellationToken).ConfigureAwait(false);
+            var relationIdentifier = (RelationIdentifier)value;
+            await stream.WriteLongAsync(relationIdentifier.OutVertexId, cancellationToken).ConfigureAwait(false);
+            await stream.WriteLongAsync(relationIdentifier.TypeId, cancellationToken).ConfigureAwait(false);
+            await stream.WriteLongAsync(relationIdentifier.RelationId, cancellationToken).ConfigureAwait(false);
+            await stream.WriteLongAsync(relationIdentifier.InVertexId, cancellationToken).ConfigureAwait(false);
         }
 
-        protected override async Task<RelationIdentifier> ReadNonNullableValueAsync(Stream stream,
+        protected override async Task<object> ReadNonNullableValueAsync(Stream stream,
             GraphBinaryReader reader, CancellationToken cancellationToken = default)
         {
             var outVertexId = await stream.ReadLongAsync(cancellationToken).ConfigureAwait(false);

--- a/test/JanusGraph.Net.IntegrationTest/IO/GraphBinary/GraphBinaryGeoshapeDeserializerTests.cs
+++ b/test/JanusGraph.Net.IntegrationTest/IO/GraphBinary/GraphBinaryGeoshapeDeserializerTests.cs
@@ -1,0 +1,37 @@
+﻿#region License
+
+/*
+ * Copyright 2023 JanusGraph.Net Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+using Gremlin.Net.Structure.IO.GraphBinary;
+using JanusGraph.Net.IO.GraphBinary;
+using Xunit;
+
+namespace JanusGraph.Net.IntegrationTest.IO.GraphBinary;
+
+[Collection("JanusGraph Server collection")]
+public class GraphBinaryGeoshapeDeserializerTests : GeoshapeDeserializerTests
+{
+    public GraphBinaryGeoshapeDeserializerTests(JanusGraphServerFixture fixture)
+    {
+        ConnectionFactory = new RemoteConnectionFactory(fixture.Host, fixture.Port,
+            new GraphBinaryMessageSerializer(JanusGraphTypeSerializerRegistry.Instance));
+    }
+
+    protected override RemoteConnectionFactory ConnectionFactory { get; }
+}

--- a/test/JanusGraph.Net.IntegrationTest/IO/GraphBinary/GraphBinaryGeoshapeSerializerTests.cs
+++ b/test/JanusGraph.Net.IntegrationTest/IO/GraphBinary/GraphBinaryGeoshapeSerializerTests.cs
@@ -1,0 +1,37 @@
+﻿#region License
+
+/*
+ * Copyright 2023 JanusGraph.Net Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+using Gremlin.Net.Structure.IO.GraphBinary;
+using JanusGraph.Net.IO.GraphBinary;
+using Xunit;
+
+namespace JanusGraph.Net.IntegrationTest.IO.GraphBinary;
+
+[Collection("JanusGraph Server collection")]
+public class GraphBinaryGeoshapeSerializerTests : GeoshapeSerializerTests
+{
+    public GraphBinaryGeoshapeSerializerTests(JanusGraphServerFixture fixture)
+    {
+        ConnectionFactory = new RemoteConnectionFactory(fixture.Host, fixture.Port,
+            new GraphBinaryMessageSerializer(JanusGraphTypeSerializerRegistry.Instance));
+    }
+
+    protected override RemoteConnectionFactory ConnectionFactory { get; }
+}

--- a/test/JanusGraph.Net.IntegrationTest/appsettings.json
+++ b/test/JanusGraph.Net.IntegrationTest/appsettings.json
@@ -1,3 +1,3 @@
 ﻿{
-  "dockerImage": "janusgraph/janusgraph:latest"
+  "dockerImage": "janusgraph/janusgraph:1.0.0-rc2"
 }


### PR DESCRIPTION
Only `Point` is supported for now, just like with GraphSON. The implementation is very similar to the original one in Java with exactly the same class structure:

- `GeoshapeSerializer`: For general Geoshape serialization.
- `GeoshapeTypeSerializer`: Base class for Geoshape type specific serializers.
- `PointSerializer`: The first specific serializer for the `Point` type.

Fixes #127