### PR TITLE
Use Super Linter instead of just Editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,6 +20,7 @@ indent_style = space
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+max_line_length = 120
 
 [*.cs]
 indent_size = 4
@@ -28,6 +29,10 @@ insert_final_newline = false
 [*.csproj]
 indent_size = 2
 insert_final_newline = false
+max_line_length = unset
+
+[*.sln]
+max_line_length = unset
 
 [*.json]
 indent_size = 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 # Copyright 2021 JanusGraph Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,16 +15,16 @@
 
 version: 2
 updates:
-- package-ecosystem: nuget
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "11:00"
-  open-pull-requests-limit: 10
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "11:00"
+    open-pull-requests-limit: 10
 
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "11:00"
-  open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "11:00"
+    open-pull-requests-limit: 10

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,3 +1,4 @@
+---
 # Copyright 2020 JanusGraph Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,24 +33,24 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-    - name: Install dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build -c Release --no-restore
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
-    - name: Pack
-      run: dotnet pack ./src/JanusGraph.Net/JanusGraph.Net.csproj -v minimal -c Release --no-build -o ./artifacts
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: artifacts
-        path: ./artifacts/*.nupkg
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+      - name: Install dependencies
+        run: "dotnet restore"
+      - name: Build
+        run: dotnet build -c Release --no-restore
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal
+      - name: Pack
+        run: dotnet pack ./src/JanusGraph.Net/JanusGraph.Net.csproj -v minimal -c Release --no-build -o ./artifacts
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: ./artifacts/*.nupkg
 
   deploy:
     needs: build
@@ -67,4 +68,4 @@ jobs:
         with:
           dotnet-version: 6.0.x
       - name: Push to NuGet Feed
-        run: dotnet nuget push './artifacts/*.nupkg' --skip-duplicate --source $NUGET_FEED --api-key $NUGET_KEY
+        run: dotnet nuget push './artifacts/*.nupkg' --skip-duplicate --source "$NUGET_FEED" --api-key "$NUGET_KEY"

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,3 +1,4 @@
+---
 # Copyright 2020 JanusGraph Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,13 +16,13 @@
 name: License Validation
 
 on:
-  pull_request: {}
+  pull_request: { }
 
 jobs:
   weasel:
     runs-on: ubuntu-20.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Run weasel
-      uses: docker://licenseweasel/weasel:v0.4
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Run weasel
+        uses: docker://licenseweasel/weasel:v0.4

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,3 +1,4 @@
+---
 # Copyright 2023 JanusGraph Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,8 +16,8 @@
 name: Linter
 
 on:
-  pull_request: {}
-  push: {}
+  pull_request: { }
+  push: { }
 
 jobs:
   check:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,4 +1,4 @@
-# Copyright 2020 JanusGraph Authors
+# Copyright 2023 JanusGraph Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,16 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Editorconfig
+name: Linter
 
 on:
   pull_request: {}
+  push: {}
 
 jobs:
   check:
     runs-on: ubuntu-20.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Run editorconfig
-      uses: docker://mstruebing/editorconfig-checker
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          # Full git history is needed to get a proper
+          # list of changed files within `super-linter`
+          fetch-depth: 0
+      - name: Lint Code Base
+        uses: github/super-linter@v5
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -5,7 +5,8 @@ JanusGraph.Net uses dotnet build for convenient builds across platforms.
 ## Requirements
 
 * [.NET 6.0 SDK (version >= 2.1.400)][dotnet-sdk] is needed to build and test the project.
-* [Docker][docker] needs to be running in order to execute the integration tests as they automatically start a JanusGraph Docker container.
+* [Docker][docker] needs to be running in order to execute the integration tests as they automatically start a
+JanusGraph Docker container.
 
 ## Build
 
@@ -37,7 +38,7 @@ and then push this tag:
 git push origin v0.1.0
 ```
 
-This will trigger a deployment via Github Actions after the usual build has completed
+This will trigger a deployment via GitHub Actions after the usual build has completed
 successfully.
 The version number used for the tag should correspond to the version in the
 `.csproj` file as that version is used for the NuGet package.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ details about this dual-license structure, please see
 [codacy-url]: https://app.codacy.com/project/JanusGraph/janusgraph-dotnet/dashboard
 [nuget-badge]: https://img.shields.io/nuget/v/JanusGraph.NET
 [nuget-url]: https://www.nuget.org/packages/JanusGraph.NET/
-[actions-badge]: https://img.shields.io/github/actions/workflow/status/JanusGraph/janusgraph-dotnet/dotnet.yml?branch=master
+[actions-badge]:
+https://img.shields.io/github/actions/workflow/status/JanusGraph/janusgraph-dotnet/dotnet.yml?branch=master
 [actions-url]: https://github.com/JanusGraph/janusgraph-dotnet/actions
 [janusgraph]: https://janusgraph.org/
 [gremlin.net]: https://tinkerpop.apache.org/docs/current/reference/#gremlin-DotNet

--- a/src/JanusGraph.Net/Geoshapes/Point.cs
+++ b/src/JanusGraph.Net/Geoshapes/Point.cs
@@ -23,8 +23,8 @@ using System;
 namespace JanusGraph.Net.Geoshapes
 {
     /// <summary>
-    ///     A single point representation. A point is identified by its coordinate on the earth sphere using the spherical
-    ///     system of latitudes and longitudes.
+    ///     A single point representation. A point is identified by its coordinate on the earth sphere using the
+    ///     spherical system of latitudes and longitudes.
     /// </summary>
     public class Point : IEquatable<Point>
     {
@@ -47,7 +47,7 @@ namespace JanusGraph.Net.Geoshapes
         /// <summary>
         ///     Gets the coordinates of this point in the form: [longitude, latitude].
         /// </summary>
-        public double[] Coordinates => new[] {Longitude, Latitude};
+        public double[] Coordinates => new[] { Longitude, Latitude };
 
         /// <inheritdoc />
         public bool Equals(Point other)
@@ -63,7 +63,7 @@ namespace JanusGraph.Net.Geoshapes
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != GetType()) return false;
-            return Equals((Point) obj);
+            return Equals((Point)obj);
         }
 
         /// <inheritdoc />

--- a/src/JanusGraph.Net/IO/GraphBinary/JanusGraphTypeSerializerRegistry.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/JanusGraphTypeSerializerRegistry.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2021 JanusGraph.Net Authors
@@ -32,7 +32,8 @@ namespace JanusGraph.Net.IO.GraphBinary
     public static class JanusGraphTypeSerializerRegistry
     {
         /// <summary>
-        ///     Provides a default <see cref="TypeSerializerRegistry" /> instance with JanusGraph types already registered.
+        ///     Provides a default <see cref="TypeSerializerRegistry" /> instance with JanusGraph types already
+        ///     registered.
         /// </summary>
         public static readonly TypeSerializerRegistry Instance = Build().Create();
 

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/GeoshapeConstants.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/GeoshapeConstants.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2023 JanusGraph.Net Authors

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/GeoshapeSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/GeoshapeSerializer.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2023 JanusGraph.Net Authors

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/GeoshapeTypeSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/GeoshapeTypeSerializer.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2023 JanusGraph.Net Authors

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/GraphBinaryType.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/GraphBinaryType.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2021 JanusGraph.Net Authors

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/JanusGraphPSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/JanusGraphPSerializer.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2021 JanusGraph.Net Authors

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/JanusGraphTypeSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/JanusGraphTypeSerializer.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2021 JanusGraph.Net Authors

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/PointSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/PointSerializer.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2023 JanusGraph.Net Authors

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/RelationIdentifierSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/RelationIdentifierSerializer.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2021 JanusGraph.Net Authors

--- a/src/JanusGraph.Net/IO/GraphSON/JanusGraphGraphSONMessageSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphSON/JanusGraphGraphSONMessageSerializer.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2021 JanusGraph.Net Authors

--- a/src/JanusGraph.Net/IO/GraphSON/JanusGraphPSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphSON/JanusGraphPSerializer.cs
@@ -27,10 +27,10 @@ namespace JanusGraph.Net.IO.GraphSON
     {
         public Dictionary<string, dynamic> Dictify(dynamic objectData, GraphSONWriter writer)
         {
-            var p = (JanusGraphP) objectData;
+            var p = (JanusGraphP)objectData;
             var value = p.Other == null
                 ? writer.ToDict(p.Value)
-                : new List<dynamic> {writer.ToDict(p.Value), writer.ToDict(p.Other)};
+                : new List<dynamic> { writer.ToDict(p.Value), writer.ToDict(p.Other) };
 
             var dict = new Dictionary<string, dynamic>
             {

--- a/src/JanusGraph.Net/IO/GraphSON/JanusGraphSONReaderBuilder.cs
+++ b/src/JanusGraph.Net/IO/GraphSON/JanusGraphSONReaderBuilder.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2018 JanusGraph.Net Authors
@@ -24,8 +24,8 @@ using Gremlin.Net.Structure.IO.GraphSON;
 namespace JanusGraph.Net.IO.GraphSON
 {
     /// <summary>
-    ///     Creates a <see cref="GraphSONReader" /> with the default JanusGraph deserializers and allows adding of custom
-    ///     deserializers.
+    ///     Creates a <see cref="GraphSONReader" /> with the default JanusGraph deserializers and allows adding of
+    ///     custom deserializers.
     /// </summary>
     public class JanusGraphSONReaderBuilder
     {
@@ -61,8 +61,8 @@ namespace JanusGraph.Net.IO.GraphSON
         }
 
         /// <summary>
-        ///     Creates a <see cref="GraphSONReader" /> with the registered deserializers as well as the default JanusGraph
-        ///     deserializers.
+        ///     Creates a <see cref="GraphSONReader" /> with the registered deserializers as well as the default
+        ///     JanusGraph deserializers.
         /// </summary>
         public GraphSON3Reader Create()
         {

--- a/src/JanusGraph.Net/IO/GraphSON/JanusGraphSONWriterBuilder.cs
+++ b/src/JanusGraph.Net/IO/GraphSON/JanusGraphSONWriterBuilder.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2018 JanusGraph.Net Authors
@@ -63,8 +63,8 @@ namespace JanusGraph.Net.IO.GraphSON
         }
 
         /// <summary>
-        ///     Creates a <see cref="GraphSONWriter" /> with the registered serializers as well as the default JanusGraph
-        ///     serializers.
+        ///     Creates a <see cref="GraphSONWriter" /> with the registered serializers as well as the default
+        ///     JanusGraph serializers.
         /// </summary>
         public GraphSON3Writer Create()
         {

--- a/src/JanusGraph.Net/IO/GraphSON/PointSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphSON/PointSerializer.cs
@@ -28,9 +28,9 @@ namespace JanusGraph.Net.IO.GraphSON
     {
         public Dictionary<string, dynamic> Dictify(dynamic objectData, GraphSONWriter writer)
         {
-            var point = (Point) objectData;
+            var point = (Point)objectData;
             return GraphSONUtil.ToTypedValue("Geoshape",
-                new Dictionary<string, object> {{"coordinates", point.Coordinates}}, "janusgraph");
+                new Dictionary<string, object> { { "coordinates", point.Coordinates } }, "janusgraph");
         }
     }
 }

--- a/src/JanusGraph.Net/IO/GraphSON/RelationIdentifierSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphSON/RelationIdentifierSerializer.cs
@@ -27,13 +27,13 @@ namespace JanusGraph.Net.IO.GraphSON
     {
         public Dictionary<string, dynamic> Dictify(dynamic objectData, GraphSONWriter writer)
         {
-            var relationIdentifier = (RelationIdentifier) objectData;
+            var relationIdentifier = (RelationIdentifier)objectData;
             return GraphSONUtil.ToTypedValue("RelationIdentifier", ValueDict(relationIdentifier), "janusgraph");
         }
 
         private static Dictionary<string, object> ValueDict(RelationIdentifier relationIdentifier)
         {
-            return new Dictionary<string, object> {{"relationId", relationIdentifier.StringRepresentation}};
+            return new Dictionary<string, object> { { "relationId", relationIdentifier.StringRepresentation } };
         }
     }
 }

--- a/src/JanusGraph.Net/JanusGraphClientBuilder.cs
+++ b/src/JanusGraph.Net/JanusGraphClientBuilder.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2018 JanusGraph.Net Authors

--- a/src/JanusGraph.Net/RelationIdentifier.cs
+++ b/src/JanusGraph.Net/RelationIdentifier.cs
@@ -115,7 +115,7 @@ namespace JanusGraph.Net
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != GetType()) return false;
-            return Equals((RelationIdentifier) obj);
+            return Equals((RelationIdentifier)obj);
         }
 
         /// <inheritdoc />

--- a/src/JanusGraph.Net/Text.cs
+++ b/src/JanusGraph.Net/Text.cs
@@ -48,8 +48,8 @@ namespace JanusGraph.Net
         /// <returns>The text predicate.</returns>
         public static P TextContainsRegex(string regex) => new JanusGraphP("textContainsRegex", regex);
         /// <summary>
-        ///     Is true if (at least) one word inside the text string is similar to the query String (based on Levenshtein edit
-        ///     distance).
+        ///     Is true if (at least) one word inside the text string is similar to the query String (based on
+        ///     Levenshtein edit distance).
         /// </summary>
         /// <param name="query">The query to search.</param>
         /// <returns>The text predicate.</returns>

--- a/src/JanusGraph.Net/Utils/LongEncoding.cs
+++ b/src/JanusGraph.Net/Utils/LongEncoding.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2021 JanusGraph.Net Authors

--- a/test/JanusGraph.Net.IntegrationTest/DocTraversalsTests.cs
+++ b/test/JanusGraph.Net.IntegrationTest/DocTraversalsTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2018 JanusGraph.Net Authors

--- a/test/JanusGraph.Net.IntegrationTest/GraphBinaryDocTraversalsTests.cs
+++ b/test/JanusGraph.Net.IntegrationTest/GraphBinaryDocTraversalsTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2021 JanusGraph.Net Authors

--- a/test/JanusGraph.Net.IntegrationTest/IO/GraphBinary/GraphBinaryGeoshapeDeserializerTests.cs
+++ b/test/JanusGraph.Net.IntegrationTest/IO/GraphBinary/GraphBinaryGeoshapeDeserializerTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2023 JanusGraph.Net Authors

--- a/test/JanusGraph.Net.IntegrationTest/IO/GraphBinary/GraphBinaryGeoshapeSerializerTests.cs
+++ b/test/JanusGraph.Net.IntegrationTest/IO/GraphBinary/GraphBinaryGeoshapeSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2023 JanusGraph.Net Authors

--- a/test/JanusGraph.Net.IntegrationTest/IO/GraphBinary/GraphBinaryRelationIdentifierSerializerTests.cs
+++ b/test/JanusGraph.Net.IntegrationTest/IO/GraphBinary/GraphBinaryRelationIdentifierSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2021 JanusGraph.Net Authors

--- a/test/JanusGraph.Net.IntegrationTest/IO/GraphSON/GraphSONRelationIdentifierSerializerTests.cs
+++ b/test/JanusGraph.Net.IntegrationTest/IO/GraphSON/GraphSONRelationIdentifierSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2018 JanusGraph.Net Authors

--- a/test/JanusGraph.Net.IntegrationTest/IO/RelationIdentifierSerializerTests.cs
+++ b/test/JanusGraph.Net.IntegrationTest/IO/RelationIdentifierSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2021 JanusGraph.Net Authors

--- a/test/JanusGraph.Net.IntegrationTest/JanusGraphServerCollection.cs
+++ b/test/JanusGraph.Net.IntegrationTest/JanusGraphServerCollection.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2018 JanusGraph.Net Authors

--- a/test/JanusGraph.Net.IntegrationTest/JanusGraphServerFixture.cs
+++ b/test/JanusGraph.Net.IntegrationTest/JanusGraphServerFixture.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2018 JanusGraph.Net Authors

--- a/test/JanusGraph.Net.IntegrationTest/TextTests.cs
+++ b/test/JanusGraph.Net.IntegrationTest/TextTests.cs
@@ -46,7 +46,8 @@ namespace JanusGraph.Net.IntegrationTest
         [InlineData("wave", 1)]
         [InlineData("f", 2)]
         [InlineData("shouldNotBeFound", 0)]
-        public async Task TextContainsPrefixgivenSearchText_ExpectedCountOfElements(string searchText, int expectedCount)
+        public async Task TextContainsPrefixgivenSearchText_ExpectedCountOfElements(string searchText,
+            int expectedCount)
         {
             var g = Traversal().WithRemote(ConnectionFactory.CreateRemoteConnection());
 

--- a/test/JanusGraph.Net.UnitTest/Geoshapes/GeoshapeTests.cs
+++ b/test/JanusGraph.Net.UnitTest/Geoshapes/GeoshapeTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2018 JanusGraph.Net Authors

--- a/test/JanusGraph.Net.UnitTest/Geoshapes/PointTests.cs
+++ b/test/JanusGraph.Net.UnitTest/Geoshapes/PointTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2018 JanusGraph.Net Authors

--- a/test/JanusGraph.Net.UnitTest/IO/GraphSON/GraphSONReaderBuilderTests.cs
+++ b/test/JanusGraph.Net.UnitTest/IO/GraphSON/GraphSONReaderBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2018 JanusGraph.Net Authors
@@ -34,10 +34,11 @@ namespace JanusGraph.Net.UnitTest.IO.GraphSON
         public void RegisterDeserializer_CustomDeserializerForGivenType_DeserializerRegistered(string graphSONType,
             object deserializationResult)
         {
-            var customDeserializer = new DeserializerFake {DeserializationResult = deserializationResult};
+            var customDeserializer = new DeserializerFake { DeserializationResult = deserializationResult };
             var graphSon = "{\"@type\":\"" + graphSONType + "\",\"@value\":0}";
 
-            var reader = JanusGraphSONReaderBuilder.Build().RegisterDeserializer(graphSONType, customDeserializer).Create();
+            var reader = JanusGraphSONReaderBuilder.Build().RegisterDeserializer(graphSONType, customDeserializer)
+                .Create();
 
             Assert.Equal(deserializationResult, reader.ToObject(JsonDocument.Parse(graphSon).RootElement));
         }

--- a/test/JanusGraph.Net.UnitTest/IO/GraphSON/GraphSONWriterBuilderTests.cs
+++ b/test/JanusGraph.Net.UnitTest/IO/GraphSON/GraphSONWriterBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2018 JanusGraph.Net Authors
@@ -37,8 +37,8 @@ namespace JanusGraph.Net.UnitTest.IO.GraphSON
         {
             var customSerializer = SerializerFake.Register(graphSonTypeToUse, dataToSerialize);
 
-            var writer = JanusGraphSONWriterBuilder.Build().RegisterSerializer(dataToSerialize.GetType(), customSerializer)
-                .Create();
+            var writer = JanusGraphSONWriterBuilder.Build()
+                .RegisterSerializer(dataToSerialize.GetType(), customSerializer).Create();
 
             Assert.Equal(customSerializer.DeserializationResult, writer.WriteObject(dataToSerialize));
         }
@@ -61,7 +61,7 @@ namespace JanusGraph.Net.UnitTest.IO.GraphSON
 
             private SerializerFake(string graphSonType, object valueToReturn)
             {
-                _typedValue = new Dictionary<string, dynamic> {{graphSonType, valueToReturn}};
+                _typedValue = new Dictionary<string, dynamic> { { graphSonType, valueToReturn } };
             }
 
             public static SerializerFake Register(string graphSonType, object valueToReturn)

--- a/test/JanusGraph.Net.UnitTest/IO/GraphSON/RelationIdentifierSerializationSymmetricyTests.cs
+++ b/test/JanusGraph.Net.UnitTest/IO/GraphSON/RelationIdentifierSerializationSymmetricyTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 /*
  * Copyright 2018 JanusGraph.Net Authors


### PR DESCRIPTION
The check for the editorconfig has been broken since a few weeks or so so I checked how to improve it. [Super Linter](https://github.com/super-linter/super-linter) is a GitHub action that includes linters for various languages and which seems to be quite popular and therefore well maintained. It also includes a linter for editorconfig.
We could use it only to enforce the editorconfig, but I I've figured that we could also enable the other linters to ensure consistent formatting in general.

By default, super linter only checks modifications in the specific push / PR, but I enabled it temporarily on my fork to lint the whole repo so I could address issues it found in the existing code space so we don't get those as errors next time we modify these files.

To make the review easier, this consists of two commits: One that enables the linters and a second which fixes all found issues.

I think we can also use this action in other repos for JanusGraph, we might just need to be careful with linting everything in the main repo as it could find a lot of issues in the existing code space which shouldn't slow down our development.