### PR TITLE
1.0.0-rc1 Release Candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ of JanusGraph.Net:
 | 0.1.z          | 0.3.z                  |
 | 0.2.z          | 0.4.z, 0.5.z           |
 | 0.3.z          | 0.4.z, 0.5.z, 0.6.z    |
-| 0.4.z          | (0.4.z, 0.5.z,)* 0.6.z |
+| 0.4.z          | (0.4.z, 0.5.z,) 0.6.z  |
+| 1.0.z          | 0.6.z, 1.0.z           |
 
 While it should also be possible to use JanusGraph.Net with other versions of
 JanusGraph than mentioned here, compatibility is not tested and some
@@ -108,9 +109,16 @@ functionality (like added Gremlin steps) will not work as it is not supported
 yet in case of an older JanusGraph version or was removed in a newer JanusGraph
 version.
 
-\* JanusGraph.Net 0.4 still supports older versions of JanusGraph, but the
+### JanusGraph.Net 0.4
+
+JanusGraph.Net 0.4 still supports older versions of JanusGraph, but the
 `janusGraphPredicates` flag needs to be set to `false` in order to be able to
 use JanusGraph's Text predicates.
+
+### JanusGraph.Net 1.0
+
+Since JanusGraph 1.0.0 is not officially released yet, we also only have prerelease versions of JanusGraph.Net.
+Note that serialization of Geoshapes via GraphBinary is only compatible with JanusGraph 1.0.0 and higher.
 
 ## Serialization Formats
 

--- a/src/JanusGraph.Net/JanusGraph.Net.csproj
+++ b/src/JanusGraph.Net/JanusGraph.Net.csproj
@@ -6,7 +6,7 @@
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>0.4.3</Version>
+    <Version>1.0.0-rc1</Version>
     <Title>JanusGraph.Net</Title>
     <Authors>JanusGraph</Authors>
     <Description>
@@ -23,7 +23,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Gremlin.Net" Version="3.6.2" />
+    <PackageReference Include="Gremlin.Net" Version="3.6.4" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\JanusGraph logomark color RGB.png" Pack="true" PackagePath="\" />


### PR DESCRIPTION
This release candidate enables .NET users to already try out the 1.0.0 release candidates of JanusGraph.

Gremlin.Net is used because it includes no breaking changes, but two bug fixes:
* memory leak if CancellationToken is used: https://issues.apache.org/jira/browse/TINKERPOP-2944
* user agent not present in all environments: https://issues.apache.org/jira/browse/TINKERPOP-2918

Especially the memory leak can be critical for JanusGraph.Net users who have already began to use the `CancellationToken` support.