### PR TITLE
Fix GraphBinary deserialization of RelationIdentifier

### DIFF
--- a/src/JanusGraph.Net/RelationIdentifier.cs
+++ b/src/JanusGraph.Net/RelationIdentifier.cs
@@ -54,10 +54,10 @@ namespace JanusGraph.Net
         /// <summary>
         ///     Initializes a new instance of the <see cref="RelationIdentifier" /> class.
         /// </summary>
-        /// <param name="outVertexId"></param>
-        /// <param name="typeId"></param>
-        /// <param name="relationId"></param>
-        /// <param name="inVertexId"></param>
+        /// <param name="outVertexId">The id of the outgoing vertex.</param>
+        /// <param name="typeId">The JanusGraph internal type id.</param>
+        /// <param name="relationId">The JanusGraph internal relation id.</param>
+        /// <param name="inVertexId">The id of the incoming vertex.</param>
         public RelationIdentifier(long outVertexId, long typeId, long relationId, long inVertexId)
         {
             OutVertexId = outVertexId;

--- a/src/JanusGraph.Net/Utils/LongEncoding.cs
+++ b/src/JanusGraph.Net/Utils/LongEncoding.cs
@@ -26,11 +26,26 @@ namespace JanusGraph.Net.Utils
     /// <summary>
     ///     Utility class for encoding longs in strings, re-implemented from its Java equivalent.
     /// </summary>
-    internal static class LongEncoding
+    /// <remarks>
+    ///     JanusGraph encodes long IDs in the <see cref="RelationIdentifier"/> as strings.
+    /// </remarks>
+    public static class LongEncoding
     {
-        private const string BaseSymbols = "0123456789abcdefghijklmnopqrstuvwxyz";
+        /// <summary>
+        ///     The symbols used for the encoding.
+        /// </summary>
+        // ReSharper disable once MemberCanBePrivate.Global
+        public static readonly string BaseSymbols = "0123456789abcdefghijklmnopqrstuvwxyz";
         private static readonly int NrSymbols = BaseSymbols.Length;
 
+        /// <summary>
+        ///     Decodes a string back into a long.
+        /// </summary>
+        /// <param name="s">The string to decode.</param>
+        /// <returns>The decoded long value.</returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown if the string contains any invalid characters. Only <see cref="BaseSymbols"/> are allowed.
+        /// </exception>
         public static long Decode(string s)
         {
             long num = 0;
@@ -46,12 +61,17 @@ namespace JanusGraph.Net.Utils
             return num;
         }
 
+        /// <summary>
+        ///     Encodes a long value as a string.
+        /// </summary>
+        /// <param name="num">The long value to encode.</param>
+        /// <returns>The encoded string value.</returns>
         public static string Encode(long num)
         {
             var sb = new StringBuilder();
             while (num != 0)
             {
-                sb.Append(BaseSymbols[(int)num % NrSymbols]);
+                sb.Append(BaseSymbols[(int)(num % NrSymbols)]);
                 num /= NrSymbols;
             }
 

--- a/test/JanusGraph.Net.UnitTest/Utils/LongEncodingTests.cs
+++ b/test/JanusGraph.Net.UnitTest/Utils/LongEncodingTests.cs
@@ -1,0 +1,42 @@
+#region License
+
+/*
+ * Copyright 2023 JanusGraph.Net Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+using JanusGraph.Net.Utils;
+using Xunit;
+
+namespace JanusGraph.Net.UnitTest.Utils;
+
+public class LongEncodingTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(1234567890)]
+    [InlineData(int.MaxValue)]
+    [InlineData((long)int.MaxValue + 1)]
+    [InlineData(long.MaxValue)]
+    public void EncodeAndDecode_ValidValue_SameValue(long toEncode)
+    {
+        var encoded = LongEncoding.Encode(toEncode);
+        var decoded = LongEncoding.Decode(encoded);
+
+        Assert.Equal(toEncode, decoded);
+    }
+}


### PR DESCRIPTION
Deserializing a RelationIdentifier with one of its four long IDs being larger than 2^32 led to an `IndexOutOfRangeException` due to missing braces that resulted in a wrong type cast to `int`.

Fixes #138

I plan to publish another release candidate for 1.0.0 after this is merged.