### PR TITLE
JanusGraph.Net 1.0.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ of JanusGraph.Net:
 | 0.2.z          | 0.4.z, 0.5.z           |
 | 0.3.z          | 0.4.z, 0.5.z, 0.6.z    |
 | 0.4.z          | (0.4.z, 0.5.z,) 0.6.z  |
-| 1.0.z          | 0.6.z, 1.0.z           |
+| 1.0.z          | (0.6.z,) 1.0.z         |
 
 While it should also be possible to use JanusGraph.Net with other versions of
 JanusGraph than mentioned here, compatibility is not tested and some
@@ -117,8 +117,9 @@ use JanusGraph's Text predicates.
 
 ### JanusGraph.Net 1.0
 
-Since JanusGraph 1.0.0 is not officially released yet, we also only have prerelease versions of JanusGraph.Net.
-Note that serialization of Geoshapes via GraphBinary is only compatible with JanusGraph 1.0.0 and higher.
+GraphBinary serialization includes breaking changes in version 1.0.0.
+JanusGraph.Net 1.0 is therefore only compatible with JanusGraph 0.6 if GraphSON
+is used.
 
 ## Serialization Formats
 

--- a/src/JanusGraph.Net/IO/GraphBinary/JanusGraphTypeSerializerRegistry.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/JanusGraphTypeSerializerRegistry.cs
@@ -37,7 +37,7 @@ namespace JanusGraph.Net.IO.GraphBinary
         /// </summary>
         public static readonly TypeSerializerRegistry Instance = Build().Create();
 
-        private static Builder Build() => new Builder();
+        private static Builder Build() => new();
 
         /// <summary>
         ///     Builds a <see cref="TypeSerializerRegistry" /> with serializers for JanusGraph types already registered.

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/GeoshapeSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/GeoshapeSerializer.cs
@@ -46,8 +46,8 @@ namespace JanusGraph.Net.IO.GraphBinary.Types
         {
         }
 
-        protected override async Task WriteNonNullableValueAsync(object value, Stream stream, GraphBinaryWriter writer,
-            CancellationToken cancellationToken = default)
+        protected override async Task WriteNonNullableValueInternalAsync(object value, Stream stream,
+            GraphBinaryWriter writer, CancellationToken cancellationToken = default)
         {
             await stream.WriteByteAsync(GeoshapeConstants.GeoshapeFormatVersion, cancellationToken)
                 .ConfigureAwait(false);
@@ -60,7 +60,7 @@ namespace JanusGraph.Net.IO.GraphBinary.Types
             await serializer.WriteNonNullableValueAsync(value, stream, writer, cancellationToken).ConfigureAwait(false);
         }
 
-        protected override async Task<object> ReadNonNullableValueAsync(Stream stream, GraphBinaryReader reader,
+        public override async Task<object> ReadNonNullableValueAsync(Stream stream, GraphBinaryReader reader,
             CancellationToken cancellationToken = default)
         {
             var formatVersion = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/JanusGraphPSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/JanusGraphPSerializer.cs
@@ -31,18 +31,18 @@ namespace JanusGraph.Net.IO.GraphBinary.Types
         {
         }
 
-        protected override async Task WriteNonNullableValueAsync(object value, Stream stream,
+        protected override async Task WriteNonNullableValueInternalAsync(object value, Stream stream,
             GraphBinaryWriter writer, CancellationToken cancellationToken = default)
         {
             var p = (JanusGraphP)value;
-            await writer.WriteValueAsync(p.OperatorName, stream, false, cancellationToken).ConfigureAwait(false);
+            await writer.WriteNonNullableValueAsync(p.OperatorName, stream, cancellationToken).ConfigureAwait(false);
             await writer.WriteAsync(p.Value, stream, cancellationToken).ConfigureAwait(false);
         }
 
-        protected override async Task<object> ReadNonNullableValueAsync(Stream stream, GraphBinaryReader reader,
+        public override async Task<object> ReadNonNullableValueAsync(Stream stream, GraphBinaryReader reader,
             CancellationToken cancellationToken = default)
         {
-            var operatorName = (string)await reader.ReadValueAsync<string>(stream, false, cancellationToken)
+            var operatorName = (string)await reader.ReadNonNullableValueAsync<string>(stream, cancellationToken)
                 .ConfigureAwait(false);
             var value = await reader.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
             return new JanusGraphP(operatorName, value);

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/JanusGraphTypeSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/JanusGraphTypeSerializer.cs
@@ -43,7 +43,7 @@ namespace JanusGraph.Net.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        public override async Task WriteAsync(object value, Stream stream, GraphBinaryWriter writer,
+        public override async Task WriteAsync(object? value, Stream stream, GraphBinaryWriter writer,
             CancellationToken cancellationToken = default)
         {
             await stream.WriteIntAsync(_type.TypeId, cancellationToken).ConfigureAwait(false);
@@ -52,7 +52,7 @@ namespace JanusGraph.Net.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        public override async Task WriteNullableValueAsync(object value, Stream stream, GraphBinaryWriter writer,
+        public override async Task WriteNullableValueAsync(object? value, Stream stream, GraphBinaryWriter writer,
             CancellationToken cancellationToken = default)
         {
             if (value == null)
@@ -90,7 +90,7 @@ namespace JanusGraph.Net.IO.GraphBinary.Types
             GraphBinaryWriter writer, CancellationToken cancellationToken = default);
 
         /// <inheritdoc />
-        public override async Task<object> ReadAsync(Stream stream, GraphBinaryReader reader,
+        public override async Task<object?> ReadAsync(Stream stream, GraphBinaryReader reader,
             CancellationToken cancellationToken = default)
         {
             var customTypeInfo = await stream.ReadIntAsync(cancellationToken).ConfigureAwait(false);
@@ -104,7 +104,7 @@ namespace JanusGraph.Net.IO.GraphBinary.Types
         }
 
         /// <inheritdoc />
-        public override async Task<object> ReadNullableValueAsync(Stream stream, GraphBinaryReader reader,
+        public override async Task<object?> ReadNullableValueAsync(Stream stream, GraphBinaryReader reader,
             CancellationToken cancellationToken = default)
         {
             var valueFlag = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);

--- a/src/JanusGraph.Net/IO/GraphBinary/Types/RelationIdentifierSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphBinary/Types/RelationIdentifierSerializer.cs
@@ -109,7 +109,7 @@ namespace JanusGraph.Net.IO.GraphBinary.Types
             var relationId = await stream.ReadLongAsync(cancellationToken).ConfigureAwait(false);
 
             var inVertexIdMarker = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
-            object inVertexId;
+            object? inVertexId;
             if (inVertexIdMarker == StringMarker)
             {
                 inVertexId = await ReadStringAsync(stream, cancellationToken).ConfigureAwait(false);

--- a/src/JanusGraph.Net/IO/GraphSON/JanusGraphGraphSONMessageSerializer.cs
+++ b/src/JanusGraph.Net/IO/GraphSON/JanusGraphGraphSONMessageSerializer.cs
@@ -60,7 +60,7 @@ namespace JanusGraph.Net.IO.GraphSON
         }
 
         /// <inheritdoc />
-        public async Task<ResponseMessage<List<object>>> DeserializeMessageAsync(byte[] message,
+        public async Task<ResponseMessage<List<object>>?> DeserializeMessageAsync(byte[] message,
             CancellationToken cancellationToken = default)
         {
             return await _serializer.DeserializeMessageAsync(message, cancellationToken).ConfigureAwait(false);

--- a/src/JanusGraph.Net/IO/GraphSON/RelationIdentifierDeserializer.cs
+++ b/src/JanusGraph.Net/IO/GraphSON/RelationIdentifierDeserializer.cs
@@ -27,7 +27,7 @@ namespace JanusGraph.Net.IO.GraphSON
     {
         public dynamic Objectify(JsonElement graphsonObject, GraphSONReader reader)
         {
-            return new RelationIdentifier(graphsonObject.GetProperty("relationId").GetString());
+            return new RelationIdentifier(graphsonObject.GetProperty("relationId").GetString()!);
         }
     }
 }

--- a/src/JanusGraph.Net/JanusGraph.Net.csproj
+++ b/src/JanusGraph.Net/JanusGraph.Net.csproj
@@ -6,6 +6,8 @@
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <LangVersion>9</LangVersion>
+    <Nullable>enable</Nullable>
     <Version>1.0.0-rc2</Version>
     <Title>JanusGraph.Net</Title>
     <Authors>JanusGraph</Authors>

--- a/src/JanusGraph.Net/JanusGraph.Net.csproj
+++ b/src/JanusGraph.Net/JanusGraph.Net.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Gremlin.Net" Version="3.6.4" />
+    <PackageReference Include="Gremlin.Net" Version="3.7.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\JanusGraph logomark color RGB.png" Pack="true" PackagePath="\" />

--- a/src/JanusGraph.Net/JanusGraph.Net.csproj
+++ b/src/JanusGraph.Net/JanusGraph.Net.csproj
@@ -8,7 +8,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>1.0.0-rc2</Version>
+    <Version>1.0.0</Version>
     <Title>JanusGraph.Net</Title>
     <Authors>JanusGraph</Authors>
     <Description>

--- a/src/JanusGraph.Net/JanusGraphClientBuilder.cs
+++ b/src/JanusGraph.Net/JanusGraphClientBuilder.cs
@@ -37,8 +37,8 @@ namespace JanusGraph.Net
         private readonly GremlinServer _server;
         private readonly JanusGraphSONReaderBuilder _readerBuilder = JanusGraphSONReaderBuilder.Build();
         private readonly JanusGraphSONWriterBuilder _writerBuilder;
-        private IMessageSerializer _serializer;
-        private ConnectionPoolSettings _connectionPoolSettings;
+        private IMessageSerializer? _serializer;
+        private ConnectionPoolSettings? _connectionPoolSettings;
 
         private JanusGraphClientBuilder(GremlinServer server)
         {

--- a/src/JanusGraph.Net/JanusGraphP.cs
+++ b/src/JanusGraph.Net/JanusGraphP.cs
@@ -24,7 +24,7 @@ namespace JanusGraph.Net
 {
     internal class JanusGraphP : P
     {
-        public JanusGraphP(string operatorName, object value, P other = null) : base(operatorName, value, other)
+        public JanusGraphP(string operatorName, object? value, P? other = null) : base(operatorName, value, other)
         {
         }
     }

--- a/src/JanusGraph.Net/RelationIdentifier.cs
+++ b/src/JanusGraph.Net/RelationIdentifier.cs
@@ -73,7 +73,7 @@ namespace JanusGraph.Net
         /// <param name="typeId">The JanusGraph internal type id.</param>
         /// <param name="relationId">The JanusGraph internal relation id.</param>
         /// <param name="inVertexId">The id of the incoming vertex.</param>
-        public RelationIdentifier(object outVertexId, long typeId, long relationId, object inVertexId)
+        public RelationIdentifier(object outVertexId, long typeId, long relationId, object? inVertexId)
         {
             OutVertexId = outVertexId;
             TypeId = typeId;
@@ -132,10 +132,10 @@ namespace JanusGraph.Net
         /// <summary>
         ///     Gets the id of the incoming vertex.
         /// </summary>
-        public object InVertexId { get; }
+        public object? InVertexId { get; }
 
         /// <inheritdoc />
-        public bool Equals(RelationIdentifier other)
+        public bool Equals(RelationIdentifier? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
@@ -143,7 +143,7 @@ namespace JanusGraph.Net
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
@@ -154,7 +154,7 @@ namespace JanusGraph.Net
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            return StringRepresentation != null ? StringRepresentation.GetHashCode() : 0;
+            return StringRepresentation.GetHashCode();
         }
 
         /// <inheritdoc />

--- a/src/JanusGraph.Net/Utils/LongEncoding.cs
+++ b/src/JanusGraph.Net/Utils/LongEncoding.cs
@@ -39,6 +39,11 @@ namespace JanusGraph.Net.Utils
         private static readonly int NrSymbols = BaseSymbols.Length;
 
         /// <summary>
+        /// Encoding used to indicate that an id is a string.
+        /// </summary>
+        public static readonly char StringEncodingMarker = 'S';
+
+        /// <summary>
         ///     Decodes a string back into a long.
         /// </summary>
         /// <param name="s">The string to decode.</param>

--- a/test/JanusGraph.Net.IntegrationTest/JanusGraphServerFixture.cs
+++ b/test/JanusGraph.Net.IntegrationTest/JanusGraphServerFixture.cs
@@ -26,6 +26,7 @@ using DotNet.Testcontainers.Configurations;
 using DotNet.Testcontainers.Containers;
 using Gremlin.Net.Driver;
 using Gremlin.Net.Driver.Remote;
+using JanusGraph.Net.IO.GraphSON;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 using static Gremlin.Net.Process.Traversal.AnonymousTraversalSource;
@@ -55,7 +56,8 @@ namespace JanusGraph.Net.IntegrationTest
         {
             try
             {
-                using var client = new GremlinClient(new GremlinServer(Host, Port));
+                using var client = new GremlinClient(new GremlinServer(Host, Port),
+                    new JanusGraphGraphSONMessageSerializer());
                 var g = Traversal().WithRemote(new DriverRemoteConnection(client));
                 return g.V().Has("name", "hercules").HasNext();
             }

--- a/test/JanusGraph.Net.IntegrationTest/appsettings.json
+++ b/test/JanusGraph.Net.IntegrationTest/appsettings.json
@@ -1,3 +1,3 @@
 ﻿{
-  "dockerImage": "janusgraph/janusgraph:1.0.0-rc2"
+  "dockerImage": "janusgraph/janusgraph:1.0.0"
 }

--- a/test/JanusGraph.Net.UnitTest/RelationIdentifierTests.cs
+++ b/test/JanusGraph.Net.UnitTest/RelationIdentifierTests.cs
@@ -34,23 +34,52 @@ namespace JanusGraph.Net.UnitTest
         }
 
         [Fact]
+        public void ToString_ValidRelationIdWithStringIDs_RelationId()
+        {
+            const string relationId = "4qp-Sout_vertex_id-7x1-Sin_vertex_id";
+            var relationIdentifier = new RelationIdentifier(relationId);
+
+            Assert.Equal(relationId, relationIdentifier.ToString());
+        }
+
+        [Fact]
         public void CtrWithStr_ValidRelationId_ExpectedLongValues()
         {
             var relationIdentifier = new RelationIdentifier("4qp-360-7x1-3aw");
 
-            Assert.Equal(4104, relationIdentifier.OutVertexId);
+            Assert.Equal(4104L, relationIdentifier.OutVertexId);
             Assert.Equal(10261, relationIdentifier.TypeId);
             Assert.Equal(6145, relationIdentifier.RelationId);
-            Assert.Equal(4280, relationIdentifier.InVertexId);
+            Assert.Equal(4280L, relationIdentifier.InVertexId);
+        }
+
+        [Fact]
+        public void CtrWithStr_ValidRelationIdWithStringIDs_ExpectedValues()
+        {
+            var relationIdentifier = new RelationIdentifier("4qp-Sout_vertex_id-7x1-Sin_vertex_id");
+
+            Assert.Equal("out_vertex_id", relationIdentifier.OutVertexId);
+            Assert.Equal(10261, relationIdentifier.TypeId);
+            Assert.Equal(6145, relationIdentifier.RelationId);
+            Assert.Equal("in_vertex_id", relationIdentifier.InVertexId);
         }
 
         [Fact]
         public void CtrWithLongs_ValidLongValues_ExpectedStringRepresentation()
         {
-            var relationIdentifier = new RelationIdentifier(4104, 10261, 6145, 4280);
+            var relationIdentifier = new RelationIdentifier(4104L, 10261, 6145, 4280L);
 
             Assert.Equal("4qp-360-7x1-3aw", relationIdentifier.StringRepresentation);
             Assert.Equal("4qp-360-7x1-3aw", relationIdentifier.ToString());
+        }
+
+        [Fact]
+        public void CtrWithLongs_ValidStringIdValues_ExpectedStringRepresentation()
+        {
+            var relationIdentifier = new RelationIdentifier("out_vertex_id", 10261, 6145, "in_vertex_id");
+
+            Assert.Equal("4qp-Sout_vertex_id-7x1-Sin_vertex_id", relationIdentifier.StringRepresentation);
+            Assert.Equal("4qp-Sout_vertex_id-7x1-Sin_vertex_id", relationIdentifier.ToString());
         }
     }
 }


### PR DESCRIPTION
This makes JanusGraph.Net compatible with the JanusGraph 1.0.0 release. Some changes were needed compared to the pre-release versions of 1.0.0:

- Update Gremlin.Net to 3.7.0 (JanusGraph 1.0.0 also uses TinkerPop 3.7.0)
- Add nullable annotations (were added in Gremlin.Net 3.7.0)
- Support string type custom vertex IDs: Required some changes to `RelationIdentifier` and `RelationIdentifierSerializer` which are backwards incompatible for GraphBinary, just like [in JanusGraph 1.0.0](https://docs.janusgraph.org/changelog/#string-vertex-id-support-breaking-change).

Note that JanusGraph.Net still only supports `-` as the delimiter character for `RelationIdentifier`. JanusGraph [offers a property](https://docs.janusgraph.org/advanced-topics/custom-vertex-id/#override-reserved-character) to change to a different character which allows users to use `-` as a character *within* vertex IDs, e.g., to use UUIDs.
I think this is a feature which we can still add to JanusGraph.Net at a later point. I'll create an issue for this when merging this PR.